### PR TITLE
docs(spec): reverse-engineered functional spec (Phase 1 of #64)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ plugin/dist/
 plugin/webxdc/mini-crossword.html
 dev/
 .claude/settings.local.json
-docs/
+docs/*
+!docs/spec/
 /scripts/

--- a/docs/spec/AUDIT.md
+++ b/docs/spec/AUDIT.md
@@ -1,0 +1,145 @@
+# Spec-vs-Code Audit
+
+Consolidated Phase-2 findings from [#64](https://github.com/jhayashi/dc-claude-channel/issues/64). Each item was surfaced while writing the per-area specs and cross-checking against source. The per-file "Audit notes" sections remain canonical; this file prioritises for triage.
+
+## Legend
+
+- **Type**: `gap` (behaviour exists but undocumented), `bug` (code does wrong thing), `contradiction` (two paths disagree), `race` (concurrency hazard), `orphan` (dead/unreachable), `doc` (documented limitation, no change proposed).
+- **Severity**: `H` ships bad behaviour to users, `M` degrades UX or observability under realistic conditions, `L` edge case or cosmetic, `A` accept as-is.
+
+---
+
+## High — user-visible or correctness-affecting
+
+- [ ] **H / race** — `close_tab` updates from file-reviewer lack `senderAddr` validation; an attacker in a group chat could spoof the close event and cause a legitimate file to be forgotten before the auto-upgrade handshake completes. *(webxdc-apps, finding 4)* Fix: validate `senderAddr` in the `close_tab` branch of `file-reviewer-app.ts`.
+
+- [ ] **H / race** — TOFU-cached `senderAddr`s in group chats never expire or re-verify. A removed group member whose addr is cached can rejoin and impersonate themselves against the WebXDC filter. *(webxdc-apps, finding 3; related to #47)* Fix: expire TOFU entries on `ChatModified` / member-list change events, or cap TTL.
+
+- [ ] **H / race** — Cache eviction during an in-flight permission hook leaves the hook client writing to a closed socket; the hook times out after 300 s and the user sees a denial instead of a clean cancellation. *(subagent-lifecycle, finding 1)* Fix: socket-server should track hook connections per chat entry and short-circuit a clean error on eviction.
+
+- [ ] **H / race** — Socket-level chat-id authorization is validated once at hello but the binding registry can mutate mid-session (agent repair, chat reassignment). Tool calls from a subagent with a just-repointed binding execute with stale authorization. *(subagent-lifecycle, finding 4)* Fix: re-check `chat_id ↔ subagentId` on every `toolCall` frame against the current binding.
+
+- [ ] **H / bug** — Skip-permissions flag (`x-dc-skipPermissions: true`) is preserved on YAML export with no warning or import prompt. Recipients silently inherit auto-approve. *(agents-and-bindings, "Skip-Permissions Leakage")* Fix: strip `x-dc-skipPermissions` on export, or show a confirmation dialog on import when the flag is present.
+
+- [ ] **H / bug** — When a sender is paired but not the owner (e.g. another participant in a group), messages are silently ignored with only a log line — unlike unpaired senders who trigger the pairing flow. From the user's side the bot looks broken. *(subagent-lifecycle, finding 8)* Fix: post a one-shot "this bot only talks to its owner" reply, or at minimum a reaction.
+
+## Medium — reliability, observability, hygiene
+
+- [ ] **M / race** — Teleport-out schedules subagent eviction 5 s after tool return. A user message during that window spawns a second subagent that races the terminal for the same session lock. *(resume, "Teleport-out mid-turn")* Fix: make the grace period explicit in the commit response and/or block dispatch during the window.
+
+- [ ] **M / race** — `version_mismatch` handshake can double-fire when two handler instances both see the stale version. Second rebuild can race the first's msgId registration, so its update lands on an unregistered msgId. File-reviewer guards via `activeViewers`; permissions-app has no equivalent. *(webxdc-apps, finding 6)* Fix: add a single-flight guard keyed by chat-id in `permissions-app.ts`.
+
+- [ ] **M / race** — Crash + LRU-evict can both call `close()` on the same process. No double-close guard; second path logs a noisy error. *(subagent-lifecycle, finding 3)* Fix: short-circuit `close()` if `alive === false`.
+
+- [ ] **M / race** — Orphaned frames/waiters in `subagent-process.ts` can grow `frameQueue` unbounded when a frame's predicate never matches before the waiter times out. *(subagent-lifecycle, finding 7)* Fix: when a waiter times out, purge frames tagged for that waiter.
+
+- [ ] **M / bug** — Rate-limit hits return boolean and drop the tool call silently from the subagent's perspective. No error surfaced to Claude. *(subagent-lifecycle, finding 10)* Fix: return a structured MCP error so the subagent can retry or back off.
+
+- [ ] **M / bug** — Pairing-code expiry (>1 h without `pair <code>`) produces a cryptic error. No in-chat "window closed, re-arm" message. *(pairing, finding 10)* Fix: post explicit expiry message in the pending chat.
+
+- [ ] **M / bug** — A stale QR scan from an unknown contact (when a primary owner is already established) is silently dropped. User watching the QR side sees nothing. *(pairing, finding 3)* Fix: surface a "not authorised" response via a securejoin-layer error.
+
+- [ ] **M / bug** — Every re-arm of `/deltachat:setup` leaves the previous "Claude" group chat on the bot side. Users who retry a few times accumulate stale groups. *(pairing, finding 4)* Fix: delete the previous pending group on re-arm.
+
+- [ ] **M / bug** — `permissionsSessions` and file-reviewer `activeViewers` maps are not cleared on chat unpair. Low-risk leak but real. *(webxdc-apps, findings 8, 9)* Fix: add `delete(chatId)` to the cleanup-event pathway.
+
+- [ ] **M / bug** — Icon cache (`agent-badges/`) has no invalidation on palette or glyph-SVG changes. Upgrades that change visuals require manual `rm -rf`. *(agents-and-bindings, "Icon Cache Invalidation")* Fix: include a palette/glyph version in the cache key.
+
+- [ ] **M / bug** — `x-dc-iconMirror` flips the Delta Chat profile image but not the in-app badge preview. Previews and notifications disagree with the chat list. *(agents-and-bindings, "Icon Mirror Inconsistency")* Fix: apply mirror in the renderer before caching.
+
+- [ ] **M / bug** — `x-dc-glyph` outside the archetype palette silently falls back with no warning. *(agents-and-bindings, "Glyph Palette Mismatch")* Fix: log a one-shot warning at render time; surface in agent-setup card.
+
+- [ ] **M / gap** — Reaction router buffers reactions in memory but never persists. Reactions emitted between buffer and flush are lost on dispatcher crash. *(subagent-lifecycle, finding 12)* Fix: persist pending reactions, or accept + document.
+
+- [ ] **M / gap** — Missed scheduled fires during dispatcher downtime are silently skipped. Acceptable policy, but undocumented in user-facing `dc_schedule` tool output. *(scheduling)* Fix: mention in tool description.
+
+- [ ] **M / gap** — No histogram for turn latency; no cache hit/miss metric. *(subagent-lifecycle, findings 17, 18)* Fix: emit structured log lines for p50/p99 tracking.
+
+## Low — edge cases, cosmetic, deferred
+
+- [ ] **L / orphan** — `isPendingPair()` in `access.ts` is exported but only used in tests. *(pairing, finding 1)* Fix: inline into tests or delete.
+
+- [ ] **L / orphan** — `cache.prewarm(chatId)` may not be exposed by `server.ts`. *(subagent-lifecycle, finding 14)* Fix: verify caller; delete if unreachable.
+
+- [ ] **L / race** — Auto-pair TOCTOU between `isKnownOwner` and `addChat`. Microsecond window; revocation would have to race a first message. *(pairing, finding 2)* Fix: acceptable as-is; note in spec.
+
+- [ ] **L / bug** — Pairing code alphabet excludes lowercase `l` for confusion-prevention but this isn't documented in user-facing help. *(pairing, finding 9)* Fix: one-liner in tutorial copy.
+
+- [ ] **L / bug** — `MAX_PENDING = 3` is per-process; dispatcher restart resets the counter. *(pairing, finding 5)* Fix: persist counter, or accept.
+
+- [ ] **L / bug** — Tutorial state not persisted; restart mid-tour drops progress. *(pairing, finding 7)* Fix: persist state keyed by chat id.
+
+- [ ] **L / bug** — `addChat()` surfaces unclear error when state dir is unwritable. *(pairing, finding 11)* Fix: clearer MCP error text.
+
+- [ ] **L / bug** — ID collision resolution on agent import produces `coach-2`, `coach-3`; no dedup for identical imports. *(agents-and-bindings, "ID Collision on Import")* Fix: content-hash compare and short-circuit if identical.
+
+- [ ] **L / bug** — `session-agents.json` entries accumulate without cleanup when a binding is deleted. Harmless leak. *(resume, "Stale session-agents entries"; agents-and-bindings, "Session-Agents Staleness")* Fix: delete reverse-index entry in `cleanupChatState`.
+
+- [ ] **L / bug** — Stale bindings between dispatcher startup and `sweepOrphans()` can cause null-pointer issues in `resolveChat()`. *(agents-and-bindings, "Stale Bindings")* Fix: run the sweep synchronously before the message router starts.
+
+- [ ] **L / bug** — `resolveChat()` returns null for a binding whose agent file was deleted; no warning until the chat tries to dispatch. *(agents-and-bindings, "Missing Agent Definition")* Fix: log a warning at load time; surface to UI.
+
+- [ ] **L / bug** — Deprecating a model in `ALLOWED_MODELS` locks agents with that model from editing. *(agents-and-bindings, "Model Migration")* Fix: allow "downgrade to latest" migration on open.
+
+- [ ] **L / bug** — Reaction dispatch is fire-and-forget; failures (rate limits, disconnected DC core) swallowed silently. *(subagent-lifecycle, finding 9)* Fix: log at `warn` level.
+
+- [ ] **L / bug** — Orphan-cleanup has no PID lockfile; two dispatchers starting concurrently can kill each other's children via the `ppid=init` heuristic. *(subagent-lifecycle, finding 13)* Fix: add a lockfile or unique dispatcher-id.
+
+- [ ] **L / bug** — Session-start hook walks the process tree up to 8 levels for flag detection; deep shell/tmux/systemd trees fall back to "assume flag present." *(pairing, finding 14)* Fix: accept, or increase the cap.
+
+- [ ] **L / doc** — `SUBAGENT_TOOL_BLOCKLIST` prevents subagents from calling pairing tools; intentional but not inline-documented. *(pairing, finding 12)* Fix: add a code comment.
+
+- [ ] **L / doc** — `DEFAULT_GATED_TOOLS` and `KNOWN_MCP_SERVERS` are hard-coded with no env/config override. *(subagent-lifecycle, findings 15, 16)* Fix: document that both are build-time constants.
+
+- [ ] **L / doc** — `suppressUserClaudeMd` flag is parsed and logged but ignored pending Claude Code support. *(subagent-lifecycle, finding 11)* Fix: comment the flag as "reserved for future use" and stop logging it.
+
+- [ ] **L / doc** — Subagent spawn failures (no agent bound) are logged but not retried; message is lost from the subagent's perspective. Expected behaviour. *(subagent-lifecycle, finding 6)* Fix: document explicitly.
+
+- [ ] **L / bug** — `onQueueDrop()` callback throws are caught silently. *(subagent-lifecycle, finding 19)* Fix: log at `warn`.
+
+- [ ] **L / bug** — Agent metadata schema accepts arbitrary `x-dc-*` keys; typos pass validation and are preserved-but-ignored. *(agents-and-bindings, "Agent Metadata Pollution")* Fix: warn on unknown keys in agent-setup UI.
+
+- [ ] **L / race** — Atomic writes use temp+rename; concurrent writes to the same agent file lose one update. *(agents-and-bindings, "Atomic Write Vulnerability")* Fix: lockfile per agent id, or accept.
+
+- [ ] **L / bug** — `buildResumeCommand()` silently downgrades to `kind: 'fresh'` when sessionId or `.jsonl` is missing. *(resume, "Observable failures")* Fix: surface the downgrade in the tool response.
+
+- [ ] **L / bug** — `isSessionLive()` returns false on fuser-error path; silent fallback. *(resume)* Fix: log once on first miss.
+
+- [ ] **L / bug** — Job-collision in `moveForChat` (target already has same jobId) throws with no recovery path. Requires manual intervention. *(resume, "Job collision on move")* Fix: rename with suffix, or document.
+
+## Accept — intentional limitations, no action proposed
+
+- [ ] **A / doc** — Single-writer invariant on session `.jsonl`; both terminal and DC reading simultaneously corrupts state. Enforced by `fuser` + `isSessionLive()`. Document in README Resume section.
+
+- [ ] **A / doc** — Resume is same-machine only. No cross-device sync. Explicit design constraint.
+
+- [ ] **A / doc** — `workingDir` is write-once per binding. Dispatcher relaunch from a different cwd keeps old bindings on their cached dir. Intentional for session-file-path stability.
+
+- [ ] **A / doc** — Familiar handler sandbox can escape via prototype-chain `Function` constructor. Defense-in-depth only; primary gate is user review at `dc_familiar_create` time. Documented in `familiar-runtime.ts`.
+
+- [ ] **A / doc** — WebXDC `setUpdateListener(fn, 0)` replay is idempotent by design; handlers must be replay-safe. Documented in CLAUDE.md.
+
+- [ ] **A / doc** — Audit log is append-only with no rotation; long-running skip-permissions agents may accumulate large files. *(skip-permissions-audit)* Cleanup is manual.
+
+- [ ] **A / doc** — Audit log stores tool inputs in plaintext; sensitive values (keys, PII) may appear. No redaction. *(skip-permissions-audit)*
+
+- [ ] **A / doc** — Shared auto-memory across all subagents on the same host. Any agent can read/write the shared `MEMORY.md`. *(CLAUDE.md)*
+
+- [ ] **A / doc** — `validateHtmlSenderAddr()` for Familiar HTML has false positives when `senderAddr` appears in a comment or string literal. *(webxdc-apps, finding 1)* Acceptable because alternative (robust JS parse) is out of scope.
+
+- [ ] **A / doc** — `APP_VERSION` monotonicity assumes single-read; edits mid-request are unrealistic in practice. *(webxdc-apps, finding 7)*
+
+- [ ] **A / doc** — Permission-prompt replay on same-msgId is rare because dispatcher reuses msgId via `permissionsSessions`. *(webxdc-apps, finding 15)*
+
+- [ ] **A / doc** — Random pairing codes exclude `l` (lowercase L) to avoid `1`/`I` confusion. *(pairing, finding 9)*
+
+- [ ] **A / doc** — Owner contact ID stored as bare integer; phantom owners still trigger auto-pair if the contact is deleted from DC core. Narrow risk. *(pairing, finding 6)*
+
+---
+
+## Next steps
+
+1. Promote any `H`-severity item that the team agrees warrants its own fix into a standalone issue; reference back here.
+2. Keep `M`/`L` items as checkboxes here; strike them as fixes land.
+3. Add a "spec still accurate?" line to the release checklist (per #64 acceptance criteria).
+4. Wire spec-to-code tie-ins into #63's regression harness where expressible as tests.

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -1,0 +1,39 @@
+# Functional Spec
+
+This directory is the canonical behavioural description of `dc-claude-channel`. Each file is a single feature area, written by reading the code that exists today — not by planning forward. It answers the question: "What is this supposed to do, where does the state live, and what can the user observe?"
+
+See [issue #64](https://github.com/jhayashi/dc-claude-channel/issues/64) for why this exists and how it fits alongside `README.md` (install), `CLAUDE.md` (architecture), and the test suite (module correctness).
+
+## Per-area specs
+
+| Area | What it covers |
+|---|---|
+| [pairing.md](pairing.md) | `/deltachat:setup`, pairing codes, securejoin, auto-pair by known owners, tutorial state machine, allowlist on disk |
+| [subagent-lifecycle.md](subagent-lifecycle.md) | LRU cache of `claude -p` children, idle-timeout eviction, stream-json I/O, Unix-socket protocol (hello / toolCall / permissionRequest / permissionVerdict), reaction mapping |
+| [agents-and-bindings.md](agents-and-bindings.md) | Agent YAML registry, per-chat bindings, templates + archetypes, badge rendering, `x-dc-*` metadata, YAML import/export |
+| [resume.md](resume.md) | DC ↔ terminal session resume, `workingDir` write-once semantics, session-agents reverse index, `dc_resume_in_terminal`, agent-setup teleport screens |
+| [webxdc-apps.md](webxdc-apps.md) | All four WebXDC apps (permissions, file-reviewer, agent-setup, marp) + Familiar runtime, auto-upgrade handshake, owner verification via `senderAddr` + TOFU, payload caps |
+| [scheduling.md](scheduling.md) | `dc_schedule` / `dc_schedule_list` / `dc_schedule_delete`, per-job atomic JSON, cron validation, missed-fire skip policy |
+| [stt.md](stt.md) | Voice transcription via `@napi-rs/whisper` + Symphonia, model download + hash pinning, worker thread, env-var config |
+| [tool-allowlisting.md](tool-allowlisting.md) | `allowedBuiltinTools` / `allowedMcpServers` on the agent definition, legacy-field migration, `--allowedTools` CLI flag format |
+| [skip-permissions-audit.md](skip-permissions-audit.md) | `x-dc-skipPermissions` auto-approve path, per-chat markdown audit log, `dc_show_audit` tool |
+
+## Cross-cutting findings
+
+[AUDIT.md](AUDIT.md) consolidates the per-file "Audit notes" sections into a single prioritised list of gaps, contradictions, and orphaned code paths. This is Phase 2 of #64 — each item is a candidate fix, follow-up issue, or explicit "accept and document."
+
+## How to keep this accurate
+
+The spec is intended to be a rolling document — git history gives the version dimension. When a PR changes behaviour:
+
+1. Update the relevant `docs/spec/<area>.md` section in the same PR.
+2. If the change adds a new feature area, add a new file and link it from this index.
+3. If the change makes an AUDIT.md finding obsolete (fixed or no longer relevant), strike it.
+
+See #64 for the broader proposal (including a planned release-checklist "spec still accurate?" step and a future regression-test tie-in via #63).
+
+## Conventions
+
+- **File-to-code pointers** — every section lists the primary source files, so a reviewer can walk from spec to code.
+- **"What the code does," not "what it should do"** — the spec describes current behaviour. Aspirational changes go through normal PR review, not spec edits.
+- **Cross-references** — if behaviour depends on another area (e.g. skip-permissions interacts with tool-allowlisting), note it in an "Interaction" subsection rather than duplicating.

--- a/docs/spec/agents-and-bindings.md
+++ b/docs/spec/agents-and-bindings.md
@@ -1,0 +1,133 @@
+# Agents, Bindings, Templates, Icons
+
+## Feature: Agents, Bindings, Templates, Icons
+
+### Intended Behavior
+
+**Agent Definitions** (`agents.ts`) represent reusable, portable Claude-powered assistant configurations stored as YAML files matching the Claude Managed Agents API schema with dc-specific `x-dc-*` extensions. Multiple chat bindings can reference the same agent definition, enabling shared behavior across chats.
+
+**Bindings** (`bindings.ts`) link a Delta Chat group to an agent definition and hold runtime state: the agent ID, Claude session UUID (for `--resume` terminal resumption), the `inheritClaudeMd` flag (whether to include CLAUDE.md in the subagent context), and the working directory where the subagent spawns. A binding may exist without an `agentId` (e.g., a chat whose first subagent spawned before setup completed); in that case the subagent runs with defaults and the binding gets populated once the user finishes setup.
+
+**Templates** (`templates.ts`) are pre-configured agent drafts shipped in `plugin/templates/*.yaml`, marked with an `x-dc-template` metadata block describing picker category, UI description, and required MCP server dependencies. The picker instantiates templates into fresh DraftAgent objects (stripped of template metadata and id), ready for the user to customize.
+
+**Icons** (`agent-icon-render.ts`) render 256×256 PNG badge images: a Lucide glyph (vendored in `agent-icons/glyphs/*.svg`) centered in a circular badge with model-family color background. Trust state (skip-permissions flag set) adds a two-tone checker pattern. The renderer is called with archetype, model family, trust flag, and glyph name; it outputs a cached PNG key-hashed by those inputs. A prebuilt directory (`agent-badges-prebuilt/`) supplies common combinations; missing files are rendered on-the-fly.
+
+**Import/Export** (`server.ts`, `tryImportAgentAttachment`): When a `.yaml` or `.yml` file is sent to a chat, the dispatcher intercepts it, parses it as an agent definition, resolves collisions by suffixing `-2`, `-3`, etc., persists it, and sends a confirmation. Rejected files (parse error, validation failure, >256 KB) receive error feedback. The import is **not transactional** — if persistence succeeds but notification fails, the agent is saved anyway.
+
+### State Machine / Transitions
+
+**Agent Lifecycle:**
+1. **Template** → instantiated as a DraftAgent (id-less, template metadata stripped).
+2. **Created** → user edits the draft and saves; id is synthesized from name (collision-resolved); YAML file written to disk.
+3. **Edited** → name, model, prompt, metadata (glyph, icon, archetype, skip-permissions) updated in-place; file rewritten atomically.
+4. **Imported** → YAML attachment is parsed, id collision-resolved, and saved (may trigger `idChanged` flag to user).
+5. **Deleted** → file removed (disallowed for built-in `claude-code` agent); any chats bound to it become orphaned but keep their binding records.
+
+**Binding Lifecycle:**
+1. **Created** → auto-created on first message in a chat (minimal binding, no agentId); or populated via agent setup UI with full binding (agentId + inheritClaudeMd).
+2. **Updated** → agent rebinding (user picks a different agent); metadata preserved (sessionId, workingDir, createdAt).
+3. **Deleted** → happens when a chat is left/deleted (unpairing); orphaned binding files may linger on disk until `sweepOrphans()` is called (once per dispatcher startup).
+4. **Cascade on Agent Delete** → **no automatic cascade**. Bindings pointing to a deleted agent remain on disk but `resolveChat()` returns null. The UI must detect orphaned chats separately.
+
+**Import State Transitions:**
+1. **Validate** → schema parse (Zod); unknown model IDs rejected.
+2. **Resolve Collision** → if id provided and exists, append `-2`, `-3`, etc.; set `idChanged` flag.
+3. **Persist** → atomic write to `agents/<agentId>.yaml` via temp + rename.
+4. **Notify** → send success or error message to chat; return true (handled).
+
+### Persisted State
+
+All directories live under `~/.claude/channels/deltachat/`:
+
+- **`agents/<agentId>.yaml`** — Agent definition file (Zod-validated YAML). Each file contains a complete AgentDef: id, name, model, description, system prompt, tools array, optional skills/mcp_servers/metadata. Example: `coach.yaml`.
+
+- **`bindings/<chatId>.json`** — Binding record (Zod-validated JSON). Schema:
+  ```json
+  { "chatId": 12345, "agentId": "coach", "sessionId": "uuid",
+    "inheritClaudeMd": false, "workingDir": "/path", "createdAt": "ISO8601" }
+  ```
+
+- **`approved/<chatId>`** — Pairing access record (simple file marker). Contains the owner's contact ID or is empty (legacy). Used by `access.isAllowed(chatId)`.
+
+- **`session-agents.json`** — Reverse index (plain JSON object `{ sessionId: agentId }`). Survives binding deletion so terminal sessions can recover the original agent on resume. Example: `{ "uuid-1": "coach", "uuid-2": "developer" }`.
+
+- **`agent-badges/<hash>.png`** — PNG cache. Key format: `{archetype}-{modelFamily}-{trust}-{glyph}.png` (e.g., `role-sonnet-plain-user-round.png`). If missing, renderer synthesizes and caches it.
+
+- **`agent-icons/glyphs/`** — Vendored Lucide SVG files (read-only, not created by runtime). New glyphs must be added manually.
+
+- **`agent-icons/palettes.ts`** — Curated glyph palettes per archetype and model-family colors (source configuration, not a file on disk). Changes require code recompile.
+
+- **`templates/`** — Built-in template YAML files (read-only). Loaded once at startup by `listTemplates()`.
+
+### Observable Surface
+
+**Agent Metadata Keys** (x-dc-* standard extensions):
+- `x-dc-archetype` — One of `role`, `utility`, `project`; defaults to `role`. Drives default icon glyph.
+- `x-dc-icon` — Explicit emoji/icon override (e.g., `"🧭"`). Falls back to archetype default if unset or empty.
+- `x-dc-glyph` — Lucide glyph name (e.g., `"cog"`, `"user-round"`). Must be in the archetype's curated palette; invalid names silently fall back to archetype default. Paired with a model-family color to render the badge.
+- `x-dc-skipPermissions` — Boolean. When `true`, subagent tool calls are auto-approved (no permission prompts). Stored only when true; absent means false.
+- `x-dc-iconMirror` — Boolean. When `true`, the chat profile image uses the horizontally-flipped glyph variant. Stored only when true.
+- `x-dc-template` — Block of template metadata (category, description, requires). **Not transferred to user agents** — stripped on instantiate.
+- `x-dc-createdAt` — ISO 8601 timestamp (when the agent definition was created).
+
+**YAML Import Contract:**
+- **Accepted Extensions:** `.yaml`, `.yml` (case-insensitive)
+- **Max Size:** 256 KB (file or parsed UTF-8 string, whichever is larger)
+- **Schema:** Must match `AgentDefSchema` (id optional, name required, model must be in `ALLOWED_MODELS`)
+- **ID Synthesis:** If `id` is absent, derived from `name` via `slugifyName` → collision-resolved with `-2`, `-3` suffix logic.
+- **ID Collision Resolution:** If provided or synthesized id exists, append numeric suffixes (first available); set `idChanged` flag in result.
+- **Rejection Reasons:** YAML parse error, schema validation failure (unknown model, missing name, invalid id format), file too large, non-UTF-8 encoding.
+- **Success Response:** `✅ Imported agent "{name}" {idChanged note}. To create a chat with it, use the agent setup card.`
+- **Error Response:** `⚠️ Couldn't import agent from "{filename}": {error}` (truncated to 200 chars for DC message length limits).
+
+**Icon Rendering Cache:**
+- **Input Keys:** `(archetype, modelFamily, trust, glyph)` → deterministic cache key `{archetype}-{modelFamily}-{trust}-{glyph}.png`.
+- **Cache Invalidation:** None. Prebuilt files are immutable; runtime-rendered PNGs persist in `agent-badges/` until manual deletion. If palette colors or glyph SVG content changes, old cached files are orphaned (no auto-cleanup, must manual-delete `agent-badges/`).
+- **Prebuilt Fallback:** Environment variable `DC_SKIP_PREBUILT=1` disables prebuilt lookup (forces render); otherwise missing prebuilt files are copied to cache on first hit.
+
+**Default Agent:**
+- Sentinel id `claude-code` is the undeletable built-in default. `deleteAgent("claude-code")` throws. `ensureDefaultAgent()` auto-seeded on startup.
+- Name, model, prompt, metadata are user-editable; existence and id are immutable.
+
+### Primary Source Files
+
+| File | Purpose |
+|------|---------|
+| `plugin/agents.ts` | AgentDef YAML registry; id/name collision resolution; archetype/icon/glyph/skip-permissions metadata accessors |
+| `plugin/bindings.ts` | Binding JSON store; session UUID management; agent resolution; orphan sweep for unpaired chats |
+| `plugin/session-agents.ts` | Persistent sessionId → agentId reverse index; survives binding deletion; used for terminal resume |
+| `plugin/templates.ts` | Template YAML loader; instantiate draft agents; Template view for picker UI |
+| `plugin/agent-icon-render.ts` | Badge PNG renderer (Lucide glyph + model color); prebuilt fallback; file cache |
+| `plugin/agent-setup-glyphs.ts` | Compile-time Lucide SVG inner-XML loader for WebXDC badge preview |
+| `plugin/agent-icons/palettes.ts` | Curated glyph palettes per archetype; model family colors (solid + checker) |
+| `plugin/agent-icons/glyphs/*.svg` | Vendored Lucide SVG files (read-only) |
+| `plugin/agent-setup.ts` | WebXDC app builder; splices glyph map into HTML at build time |
+| `plugin/server.ts` (`tryImportAgentAttachment`) | YAML attachment interception; collision-resolved import; user feedback |
+| `plugin/models.ts` | Model list, tier-based system prompts, inheritClaudeMd policy |
+| `plugin/access.ts` | Pairing/approval state; used by `bindings.countByAgentId` and `sweepOrphans` |
+
+### Audit Notes
+
+**Stale Bindings:** When a chat is left/deleted (unpairing), the binding file lingers on disk. `bindings.sweepOrphans()` (called once at dispatcher startup) removes files whose chatId is no longer in the access list. However, **between startup and the sweep, invalid bindings may be found and cause null-pointer issues** if code assumes `resolveChat()` always succeeds for a bound chat.
+
+**Orphaned Agents:** When an agent definition is deleted via `deleteAgent()`, no cascade happens. Bindings still point to the deleted agentId; `resolveChat()` returns null. The UI must detect this and show a "missing agent" state. No automatic rebinding or migration.
+
+**Icon Cache Invalidation:** When palette colors are tweaked in `palettes.ts` or glyph SVG content changes, existing cached PNG files remain unchanged (no invalidation mechanism). Old files are orphaned in `agent-badges/`. Manual deletion required; no TTL or version tracking.
+
+**Glyph Palette Mismatch:** If an agent has `x-dc-glyph: invalid-name` (outside its archetype palette), the renderer silently falls back to the default glyph without warning. User is unaware their custom glyph was ignored.
+
+**Missing Agent Definition:** If a binding exists but the referenced agent file is deleted, `resolveChat()` returns null. No warning is logged at load time; error only surfaces when that chat tries to spawn a subagent.
+
+**Model Migration:** If a model ID is removed from `ALLOWED_MODELS` (e.g., deprecated model sunsetted), existing agents with that model cannot be edited (validation fails). They remain on disk but are "stuck" — no way to upgrade without manual YAML editing.
+
+**ID Collision on Import:** Collision resolution appends `-2`, `-3` suffixes, but this can create confusing IDs. Example: importing `coach.yaml` twice yields `coach` and `coach-2`. No deduplication of intent (both might be identical copies).
+
+**Session-Agents Staleness:** If a binding is deleted but the session is still active (resuming in terminal), `session-agents.json` still has the mapping. Resume works correctly, but old entries accumulate over time (no cleanup on binding delete).
+
+**Agent Metadata Pollution:** User can manually edit YAML files (advanced use case) and insert unknown `x-dc-*` keys. Unknown metadata passes schema validation (metadata is `Record<string, unknown>`) and is preserved but ignored by the runtime. No schema validation of metadata keys.
+
+**Skip-Permissions Leakage:** An agent with `x-dc-skipPermissions: true` auto-approves tool calls. If a user exports this agent YAML and shares it, the recipient receives an agent with this flag intact. No audit trail or warning on import.
+
+**Atomic Write Vulnerability:** Agent and binding save operations use atomic temp + rename, but in high-contention scenarios (concurrent saves to the same file), last-writer-wins. If two processes both update the same agent, one update is silently lost.
+
+**Icon Mirror Inconsistency:** The `x-dc-iconMirror` flag affects the chat profile image but is not reflected in the badge renderer (`agent-icon-render.ts`). The actual glyph is never flipped in previews or notifications — only the final Delta Chat profile image flips it (external client rendering).

--- a/docs/spec/pairing.md
+++ b/docs/spec/pairing.md
@@ -1,0 +1,170 @@
+# Pairing and Access Control
+
+## Feature: Pairing and access control
+
+### Intended behavior
+
+A newly installed Claude Code plugin is unpaired (no Delta Chat contacts have access). The user must pair a phone via QR code to grant it access to Claude.
+
+**Pairing flow (happy path):**
+
+1. User runs `/deltachat:setup` in the terminal.
+2. Plugin arms a 5-minute pairing window and creates a "Claude" group chat server-side.
+3. Plugin prints a browser link that displays a QR code.
+4. User scans the QR from Delta Chat on their phone using the "Scan QR code" feature.
+5. Plugin detects the securejoin-complete event from Delta Chat core (verified-contact completion at 1000/1000 progress).
+6. Plugin checks: if the armed window is still active AND either no owner exists yet OR the contact is a known owner, it posts a welcome message into the newly-created 1:1 chat with a 5-letter pairing code (e.g., "abcde").
+7. User reads the code in Delta Chat, returns to the terminal, and runs `/deltachat:setup pair abcde`.
+8. Plugin validates the code, approves the chat, and starts the onboarding tutorial.
+9. User completes the tutorial (permission prompt, file reviewer, agent setup, optional game build).
+10. Chat is now paired; subsequent messages from that contact are routed to the default agent.
+
+**Fallback flows:**
+
+- If the user sends a message in an unpaired chat before running `/deltachat:setup pair`, the plugin posts a pairing code inline (requires completing pairing from terminal).
+- If a known owner (someone who already paired a device) sends the first message in an unpaired chat, the chat is instantly auto-paired to that contact (skips tutorial, routes directly to subagent).
+- If multiple devices are paired, only the first device can initiate new pairings via securejoin (subsequent scans of stale QR links are ignored if sent by unknown contacts).
+
+### State machine / transitions
+
+**Unpaired chat states:**
+- `UNPAIRED_UNKNOWN`: No owner has initiated contact. Any contact sending a message → `AWAITING_PAIR_CODE` (code generated, awaited).
+- `AWAITING_PAIR_CODE`: Code is pending (in-memory, 1-hour TTL). Contact sends `/deltachat:setup pair <code>` → `PAIRED` (on success) or `AWAITING_PAIR_CODE` (wrong code, code expired).
+
+**Paired chat states:**
+- `PAIRED_TUTORIAL_OFFERED`: Freshly paired, tutorial not started. User answers yes/no → `TUTORIAL_PERMISSIONS` / `TUTORIAL_DONE`.
+- `TUTORIAL_PERMISSIONS` / `TUTORIAL_FILE` / `TUTORIAL_AGENT` / ... : Multi-step tutorial with yes/no branches and optional game build at the end.
+- `TUTORIAL_DONE`: Tutorial complete or skipped. Chat is live; messages routed to subagent.
+
+**Armed window (pairing window state):**
+- `DISARMED` (default): No pending pairing. `/deltachat:setup` → `ARMED_5MIN`.
+- `ARMED_5MIN`: 5-minute TTL. Securejoin-complete event during this window → consumes window, posts code if conditions met. Window expires → auto-clears.
+
+**Owner/access gates (after first pair):**
+- If any chat has an owner set, only known owners can:
+  - Initiate new pairings via securejoin during armed window.
+  - Auto-pair when sending first message to unpaired chat.
+- Unknown contacts sending first message to unpaired chat are silently ignored (logged but no response).
+
+### Persisted state
+
+**Files on disk:**
+
+1. **Approved chats allowlist:** `~/.claude/channels/deltachat/approved/<chatId>`
+   - One file per approved chat ID (integer filename).
+   - **Content:** Contact ID (integer) on a single line, or empty (legacy, pre-owner-tracking).
+   - **Lifecycle:** Created by `completePairing()` during `/deltachat:setup pair <code>`. Deleted by `removeChat()` during unpair. Read at startup by `allowedChats()`, `isAllowed()`, `getOwner()`.
+
+2. **Tutorial state (in-memory, not persisted):** Map<chatId, TutorialState>
+   - Tracks onboarding progress per chat.
+   - **Reset at:** Session restart (lost), or explicitly by `/deltachat:setup tour` or `/tour` chat command.
+   - **Read by:** `handleMessage()` to advance tutorial, `handleAppResponse()` to react to WebXDC app interactions.
+
+3. **Arm-window state (in-memory, not persisted):** `{ _armedUntil: timestamp | null, _armedGroupChatId: groupChatId | null }`
+   - **Lifetime:** 5 minutes from `armPairing()` call, or until consumed by `consumeArmedWindow()` (whichever comes first).
+   - **Group chat:** Created by `dc_access_arm_pairing` tool, stamped with default agent's icon. Returned to user as QR. Re-created on each `/deltachat:setup` (old group left on server if not cleaned up).
+
+4. **Pending pairings (in-memory):** Map<code, { chatId, contactId, createdAt }>
+   - **Lifetime:** 1 hour (`PAIRING_EXPIRY_MS = 3,600,000` ms). Pruned automatically by `pruneExpired()`.
+   - **Idempotency:** Same chatId re-requesting pairing before the code expires returns the same code.
+   - **Limit:** Max 3 concurrent pending codes per process; `startPairing()` throws if exceeded.
+
+### Observable surface
+
+**Slash commands:**
+
+- `/deltachat:setup` — Arm pairing window, create group, print QR link. No args.
+- `/deltachat:setup pair <code>` — Complete pairing. Validates code, approves chat, starts tutorial. `code` is 5 lowercase letters.
+- `/deltachat:setup unpair [<contact_id>] [freeze|delete]` — Revoke access. No args: list paired contacts. With contact_id: unpair that device (freeze: leave chat read-only; delete: remove chat entirely).
+- `/deltachat:setup list` — Debug tool; show approved chat IDs.
+- `/deltachat:setup tour [<chat_id>]` — Restart tutorial in a paired chat. Optional numeric chat_id.
+
+**Hooks (executed by Claude Code harness):**
+
+- **SessionStart** (`plugin/scripts/session-start.sh`): Detects if plugin is loaded and channel flag present. If no chat is paired, shows unpaired-session banner with `/deltachat:setup` prompt. Exits 0 on any transient error.
+
+**Messages dispatched into Delta Chat:**
+
+- *"Hi, I'm Claude. To finish pairing, run this in your terminal: `/deltachat:setup pair <code>`"* — Posted to 1:1 chat during securejoin-complete + armed window.
+- *"Pairing required — run in Claude Code: `/deltachat:setup pair <code>`"* — Posted to unpaired chat on first message from unknown contact (fallback if securejoin didn't arm).
+- Tutorial messages (5 steps, per `tutorial.ts` state machine):
+  - Offer to tour 3 apps.
+  - Explain permission prompts + send test prompt.
+  - Explain file reviewer + send sample file.
+  - Offer to create new agent/chat.
+  - Offer to build a game.
+
+**WebXDC cards (sent during pairing):**
+
+- **Permission Prompt** (`webxdc/permission-prompt.html`): Demo permission card showing Allow/Deny buttons. Sent by tutorial step 1, intercepted to advance tutorial on tap.
+- **File Reviewer** (`webxdc/file-reviewer.html`): Document viewer with syntax highlighting + inline comments. Sent by tutorial step 2, intercepted on interaction.
+- **Agent Setup** (`webxdc/agent-setup.html`): Agent creation form + paired-devices list. Sent by tutorial step 3. Used for future agent management, not tutorial.
+
+**MCP tools (permission-gated, available in terminal only):**
+
+- `dc_access_arm_pairing()` → arms window, returns "Pairing armed for 5 minutes (until ISO-8601)".
+- `dc_access_pair(code: string)` → validates & completes pairing, starts tutorial, returns "Paired chat {chatId} successfully".
+- `dc_access_list()` → returns list of allowed chat IDs (for debugging).
+- `dc_access_unpair(contact_id?: number, mode?: 'freeze'|'delete')` → unpairs device(s), posts farewell, returns count of chats affected.
+- `dc_start_tutorial(chat_id?: number)` → restarts tutorial in specified (or only) paired chat.
+- `dc_invite_link()` → returns invite link SVG QR from bot's account (not chat-specific, created at account init).
+
+### Primary source files
+
+- **`plugin/access.ts`** (~313 lines): Allowlist file I/O, pairing code generation/validation, arm-window state, owner tracking, `listPaired()` for UI display.
+- **`plugin/tutorial.ts`** (~248 lines): Onboarding state machine (7 states: offered, permissions_explain, file_explain, agent_offered, agent_wait, phase2_offered, game_choice, done). Yields actions (messages, app cards, handoff) per user input.
+- **`plugin/server.ts`** (pairing-related sections): MCP tool handlers for `dc_access_*` and `dc_start_tutorial`. Event handlers: `onSecurejoinComplete()` posts pairing code if window armed. `handleUnpairedMessage()` auto-pairs or generates fallback code. Tutorial intercept in `dispatchPairedMessage()`.
+- **`plugin/dc-client.ts`** (~678 lines): RPC wrapper; `onSecurejoinComplete()` handler fires when DC core signals securejoin progress=1000. `getContact()`, `createGroup()` used by pairing flow.
+- **`plugin/scripts/session-start.sh`** (~93 lines): Bash hook; detects channel flag, checks for ≥1 approved chat, prints unpaired-session banner if needed.
+- **`plugin/skills/setup/SKILL.md`** (~123 lines): User-facing skill definition; dispatches on `/deltachat:setup` argument, calls MCP tools, shows QR link and tutorial guidance.
+
+### Audit notes
+
+1. **`isPendingPair()` is orphaned** (`access.ts`): Exported but never called in the codebase. Used only by tests. Unclear intent — appears to be a debugging utility but not integrated into any flow.
+
+2. **TOCTOU in auto-pair logic** (`server.ts`, unpaired-message handler):
+   - Race: Between checking `isKnownOwner(contactId)` and calling `addChat(chatId, contactId)`, the contact could be revoked via `/deltachat:setup unpair` in another terminal.
+   - Impact: Rare (microsecond window), but if triggered, the chat would be approved despite the contact being mid-revocation.
+
+3. **Silent failure if contact becomes unknown during securejoin** (`server.ts`, securejoin-complete handler):
+   - If owner is established (≥1 paired chat), a stale QR scan by an unknown contact is silently dropped (logged, no message to chat).
+   - User sees no feedback; they wait for the code that never comes.
+
+4. **Arm-window cleanup on re-arm** (`server.ts`, `dc_access_arm_pairing` handler):
+   - Old "Claude" group chat is left on the bot's side.
+   - User may end up with multiple stale "Claude" groups if they re-arm many times without finishing pairing.
+
+5. **MAX_PENDING = 3 limit is per-process, not global** (`access.ts`):
+   - If the dispatcher crashes and restarts, the pending-pairing counter resets.
+   - Impact: Low; can lead to unexpected "too many pending pairings" errors mid-recovery.
+
+6. **Owner contact ID stored as bare integer** (`access.ts`):
+   - No validation that the contact ID is valid/exists in Delta Chat.
+   - Phantom owners can still trigger auto-pair if contact is deleted from DC.
+
+7. **Tutorial state not persisted** (`tutorial.ts`, `server.ts`):
+   - Restarting the session mid-tutorial loses progress.
+   - User must re-run `/deltachat:setup tour` or `/tour` in the chat to restart.
+
+8. **`createGroup()` race with securejoin** (`server.ts`):
+   - Sequencing is tight but not atomically gated; theoretical race where joiner lands in 1:1 before group exists.
+
+9. **Pairing code alphabet excludes 'l' (lowercase L)** (`access.ts`):
+   - `CODE_ALPHABET = "abcdefghijkmnopqrstuvwxyz"`.
+   - Prevents confusion with '1' or 'I', but not documented in user-facing help.
+
+10. **No expiry message posted when pairing code expires** (`server.ts`):
+    - User waiting >1 hour before running `pair <code>` gets a cryptic error.
+    - Better UX: post "pairing window closed" in chat with re-arm suggestion.
+
+11. **`addChat()` silently succeeds if directory is unwritable** (`access.ts`):
+    - `mkdirSync` / `writeFileSync` errors are caught by MCP handler and returned to user; message could be clearer.
+
+12. **Subagent blocklist prevents in-chat agents from calling pairing tools** (`server.ts`, `SUBAGENT_TOOL_BLOCKLIST`):
+    - Intentional (prevents agents from auto-pairing or revoking), but not documented inline.
+
+13. **Missing validation of chatId in `dc_start_tutorial`** (`server.ts`):
+    - Validates integer + allowlist; doesn't verify chat still exists in DC core.
+
+14. **Session-start hook walks process tree up to 8 levels** (`session-start.sh`):
+    - Multiple shell/tmux/systemd layers can cause flag detection to fall back to "assume flag present" — may mask actual flag-missing cases.

--- a/docs/spec/resume.md
+++ b/docs/spec/resume.md
@@ -1,0 +1,115 @@
+# Session Resume / Teleport
+
+## Feature: Session resume / teleport
+
+### Intended behavior
+
+**DC → terminal**: User selects "Send chat to terminal" in agent-setup app. App builds a command via `buildResumeCommand()`, sends cleanup notifications, evicts the subagent, moves or deletes scheduled jobs, and posts the terminal command (`cd <cwd> && claude --resume <uuid>`). The user copies and pastes it after the turn ends. The DC chat is left; the binding is deleted; the session `.jsonl` remains on disk and can be resumed independently from the terminal.
+
+**Terminal → DC**: User selects "Resume a session in DC" in agent-setup app. App lists available sessions from `~/.claude/projects/*/*.jsonl` via `listResumeCandidates()`, filters out live (open-file-handles) and already-bound sessions, and presents sorted by mtime. User picks a session; app calls `resumeAttachToChat()`, creates a new DC chat, binds it to the session's original or inferred agent, and imports the session UUID. A background LLM turn generates a summary and chat title.
+
+### State machine / transitions
+
+**Session states** (from resume perspective):
+- **Terminal-origin**: `.jsonl` created by `claude` CLI in `~/.claude/projects/<cwd-hash>/`. Not bound to any DC chat initially.
+- **DC-origin**: `.jsonl` created when a DC chat spawns a subagent. Initially DC-bound; may become orphaned if the binding is deleted without cleanup.
+- **DC-origin-orphan**: Session UUID points to a `.jsonl` on disk; binding has been deleted or chat was left. Session-agents index still maps sessionId → agentId for recovery.
+- **Currently-bound**: A binding record exists mapping chatId → sessionId + workingDir.
+- **Live (held open)**: Process has the `.jsonl` file open (detected via `fuser`). Single-writer invariant — only one side (DC subagent or terminal Claude) may access the session at a time.
+- **Cold**: File exists but no process is accessing it.
+
+**Transitions**:
+- **Terminal spawns session**: Creates cold terminal-origin `.jsonl` in project-hash dir.
+- **DC spawns for new chat**: Creates cold DC-origin `.jsonl`, records sessionId in binding.
+- **DC teleports out**: Subagent evicted, binding deleted, scheduled jobs moved/deleted, chat left → terminal-origin (orphaned binding deleted, sessionId freed for terminal attach).
+- **Terminal joins DC chat**: `attachSessionToChat()` reads origin cwd from `.jsonl`, creates binding with sessionId + workingDir → currently-bound DC-origin.
+- **DC resuming terminal session**: Terminal-origin becomes currently-bound via attach.
+- **Session locked by live process**: Excluded from resume list; re-checked at attach time with `isSessionLive()` as a guard against TOCTOU race.
+
+### Persisted state
+
+**`workingDir` field on binding** (`~/.claude/channels/deltachat/bindings/<chatId>.json`):
+- Semantics: The directory the subagent is spawned in, and emitted by `buildResumeCommand()` as the `cd` target.
+- Write-once-ness: Set on first subagent spawn (to dispatcher's `process.cwd()` for DC-native chats, or to origin cwd for terminal-origin sessions via `attachSessionToChat()`). Persisted atomically alongside sessionId. Once set, never changes — ensures `claude --resume <uuid>` finds the `.jsonl` on first try without needing to hash-search.
+- Fallback: Older bindings (pre-`workingDir`) use PLUGIN_DIR as cwd; modern code prefers lossless `readSessionCwd()` from `.jsonl` header over lossy reverse-hash.
+
+**Session-agents index** (`~/.claude/channels/deltachat/session-agents.json`):
+- Maps sessionId → agentId (string → string JSON object).
+- Written: Every time `bindings.saveBinding()` stores a binding with both sessionId and agentId. Invoked on agent creation, binding updates, and resume-attach.
+- Consulted: By `resume_attach` handler to recover the original agent when pulling a terminal session into a new DC chat. Survives binding deletion — orphan sessions can still find their agent on re-import.
+- Semantics: Single-writer per session (dispatcher only). In-memory cache loaded once and persisted on write.
+
+**Claude's `.jsonl` files** (`~/.claude/projects/<cwd-hash>/<sessionId>.jsonl`):
+- Read by `resume.ts` helpers: `readSessionMeta()` (head + tail scan for summary, custom-title, message-count estimate), `readSessionCwd()` (first ~16 KB for original cwd), `readRecentTurns()` (tail ~32 KB for LLM summary generation).
+- Never written by this plugin — Claude's session store is read-only. Plugin only controls the binding (which sessionId is paired).
+- Lossless cwd extraction: Inline JSON field on user/assistant turns beats project-hash reverse (lossy when paths contain `-`).
+
+**Scheduled jobs under a session** (`~/.claude/channels/deltachat/schedules/<chatId>-<jobId>.json`):
+- On teleport-out: `scheduleStore.moveForChat(fromChatId, toChatId)` renames every job file from `<fromChatId>-*.json` to `<toChatId>-*.json` and rewrites the `chatId` field inside. Transactional — throws before touching disk if a jobId collision would occur.
+- Alternative: `deleteForChat()` removes all jobs if the user doesn't opt to preserve them.
+- Semantics: Jobs are bound to a chatId, not a sessionId. Teleport-out must move them manually to preserve scheduled behavior on the receiving chat.
+
+### Observable surface
+
+**`dc_resume_in_terminal` tool**:
+- Input: `chat_id` (string, required) — the DC chat to resume.
+- Output: Success case: returns `{ content: [{ type: 'text', text: 'Resume command already sent...' }] }`. Command is posted directly to the chat via `client.send()` to guarantee visibility. Subagent should NOT echo the tool result.
+- Async cleanup (5 s timeout): Goodbye message, evict subagent, move/delete jobs, leave chat, delete binding.
+- Error cases: Missing `chat_id`, unauthorized chat, no binding, session file deleted → error messages returned to subagent.
+
+**Agent-setup resume screens** (inputs / outputs, UI not covered):
+- `resume_list_request`: Subagent requests list of candidates. Server responds with `resume_list` payload: `{ type: 'resume_list', candidates: Candidate[], requestId, version, ... }`.
+- `Candidate` fields: `sessionId`, `sessionPath`, `cwd`, `mtimeMs`, `summary`, `sessionName`, `messageCount`.
+- `teleport_out_list_request`: App requests list of paired chats with resume info. Server responds with `teleport_out_list` payload: `{ type: 'teleport_out_list', chats: TeleportOutChat[], ... }`.
+- `TeleportOutChat` fields: `chatId`, `chatName`, `agentId`, `agentName`, `jobCount`, `isTrusted`, `isLive` (fuser check), `sessionId`, `workingDir`.
+- `resume_attach`: User picks a session. Payload: `{ type: 'resume_attach', sessionId, requestId }`. Server responds with `resume_attach_ok` (new chat created) or `resume_attach_err` (session live, already bound, not found, etc.).
+- `teleport_out_commit`: User confirms send-to-terminal with job disposition. Payload: `{ type: 'teleport_out_commit', chatId, jobDisposition, requestId }`. Server streams progress updates (`teleport_out_progress` with step/status/detail) then `teleport_out_done` or `teleport_out_error`.
+
+**Terminal command string format**:
+```
+cd <workingDir> && claude --resume <sessionId> --name '<chatName>'
+```
+Shell-quoted chat name (optional) for session display. Command must be pasted after the turn ends (5 s grace period) to avoid file-lock contention with the DC subagent.
+
+### Primary source files
+
+| File | Purpose |
+|------|---------|
+| `plugin/resume.ts` | Core session UUID ↔ `.jsonl` mapping, `buildResumeCommand()`, `listResumeCandidates()`, `attachSessionToChat()`, `isSessionLive()`, fuser integration. |
+| `plugin/bindings.ts` | Binding registry (chatId → sessionId, agentId, workingDir, createdAt), atomic save/load via temp+rename, orphan sweep. |
+| `plugin/session-agents.ts` | Persistent sessionId → agentId reverse index for orphan recovery, in-memory cache with file-based persistence. |
+| `plugin/dispatcher/schedule-store.ts` | Job file I/O, `moveForChat()` for teleport-out, `deleteForChat()` for cleanup. |
+| `plugin/server.ts` | `dc_resume_in_terminal` tool registration and implementation, `cleanupChatState()` helper, subagent spawn with workingDir persistence. |
+| `plugin/cleanup.ts` | `decideCleanup()` logic for detecting abandoned chats (bot removed or bot-alone), used by event handlers. |
+| `plugin/apps/agent-setup-app.ts` | `buildTeleportOutList()`, resume flow handlers (`resume_list_request`, `resume_attach`, `teleport_out_list_request`, `teleport_out_commit`), orphan-chat sweep via `sweepDeadChats()`. |
+
+### Audit notes
+
+**Known constraints**:
+- **Single-writer invariant**: One `.jsonl` file, one live process at a time. Enforced by `fuser` checks at attach time (terminal-to-DC) and resume list exclusion (DC-to-terminal). If both sides hold the file simultaneously, session state corrupts.
+- **Same-machine only**: Resume does not sync sessions across devices. Requires local `~/.claude/projects/` and `~/.claude/channels/` dirs.
+- **Binding write-once-ness**: `workingDir` never changes after first assignment. If dispatcher relaunches from a different dir, old bindings keep their cached dir; new DC chats adopt the new launcher cwd. Mixed dirs in the same session can cause hash mismatches.
+
+**Races**:
+- **Teleport-out mid-turn**: Subagent is evicted 5 s after tool returns. If user sends another message before that grace period, new subagent spins up and races the old session lock with the terminal. Guard: User told to wait for turn to end before pasting.
+- **Attach with live session**: User picks a session that goes live between list and attach. Guard: `isSessionLive()` re-checks at attach time; returns error if session is open (race-aware but not race-free).
+- **Job collision on move**: If target chat already has a jobId from the source chat (extremely rare), `moveForChat()` throws before writing; admin intervention needed to resolve.
+
+**Orphan accumulation**:
+- **Orphan bindings**: Occur when a session is teleported out (binding deleted) but `session-agents.json` entry persists. Sweep at dispatcher startup via `bindings.sweepOrphans()` removes bindings whose chatId is not in the access list.
+- **Stale session-agents entries**: No automatic cleanup. If a binding is deleted before the reverse-index entry is written (e.g., crash mid-write), the index entry leaks. Harmless but accumulates over time.
+- **Orphan DC-origin sessions**: A session `.jsonl` on disk whose binding was deleted. Included in resume list so user can recover. Identified by absence of binding but presence of `.jsonl` + mtime within cutoff window.
+
+**Observable failures**:
+- `listResumeCandidates()`: Excludes sessions already bound (checked against all bindings), already held open (fuser returns 0), older than 5 days (default cutoff). Lossy `cwdFromProjectHash()` if old-style project hash dir exists; no warning.
+- `isSessionLive()`: Returns false on fuser error (timeout 3 s, falls through to false if binary missing). Silent non-fatal fallback.
+- `buildResumeCommand()`: Returns `kind: 'fresh'` fallback if binding exists but sessionId or `.jsonl` is missing — emit `cd ... && claude` instead of `--resume`.
+- `attachSessionToChat()`: Throws if sessionId already bound to a different chat (prevents double-bind) or sessionId not found on disk.
+
+**Key file:line references**:
+- `resume.ts` — `buildResumeCommand()` main logic, `isSessionLive()` via fuser, `listResumeCandidates()` scanning + filtering, `attachSessionToChat()` binding update with cwd recovery.
+- `bindings.ts` — `saveBinding()` atomic write + session-agents update.
+- `session-agents.ts` — `setAgentForSession()` persist.
+- `schedule-store.ts` — `moveForChat()` transactional job migration.
+- `server.ts` — `dc_resume_in_terminal` tool impl, post-turn cleanup via `setTimeout`; `cleanupChatState()` teardown helper called by resume-out and unpair.
+- `agent-setup-app.ts` — WebXDC resume and teleport handlers (list, attach, commit).

--- a/docs/spec/scheduling.md
+++ b/docs/spec/scheduling.md
@@ -1,0 +1,67 @@
+# Scheduled Jobs
+
+## Feature: Scheduled jobs
+
+### Intended behavior
+
+Agents can schedule recurring or one-shot prompts to fire into a chat as synthetic user turns at specified times. Jobs persist across dispatcher restarts and are independent of subagent lifetime. Scheduled jobs execute under the same agent binding as the chat, subject to chat-access controls and allowed-tool restrictions (per-agent `allowedBuiltinTools` and `allowedMcpServers` are honored when the job fires).
+
+Each job has an optional expiration timestamp (`expiresAt`, ISO 8601); recurring jobs are dropped when expired. One-shot jobs that fire in the past are skipped on startup (no catch-up policy). The job-creation endpoint (`dc_schedule`) warns if a cron expression would fire >30 times in the next 7 days.
+
+### State machine / transitions
+
+- **Creation** — User calls `dc_schedule` with cron, prompt, recurring flag, optional `expiresAt`. Cron is validated via cron-parser. For one-shot jobs, the next fire time (`targetMs`) is pre-computed at creation. Job is written to disk via `ScheduleStore.save()` and added to the in-process scheduler.
+- **Arming** — Scheduler calculates the nearest future fire time across all jobs, arms a single `setTimeout` for that moment (capped at 2^31-1 ms ≈ 24.8 days; overflow re-arms on wake).
+- **Fire** — At `armedFor` time, scheduler loads all jobs from disk, filters by expiration and fire eligibility. Due jobs dispatch via `dispatch(chatId, text)`, which sends a synthetic user turn through `subagentCache.dispatch`. Recurring jobs update `lastFiredAt`; one-shots are deleted.
+- **Deletion** — User calls `dc_schedule_delete(chatId, jobId)`. Scheduler re-arms immediately.
+- **Cleanup** — On graceful shutdown, `stop()` clears the timer. Expired jobs and past-due one-shots are reaped on next startup via `reapStaleOnStartup()`.
+
+### Persisted state
+
+**Location:** `~/.claude/channels/deltachat/schedules/<chatId>-<jobId>.json` (per-job atomic files).
+
+**Format:** `ScheduledJob` object:
+```json
+{
+  "jobId": "string (6-char random slug)",
+  "chatId": 12345,
+  "cron": "5-field cron expression",
+  "prompt": "string (≤4000 chars)",
+  "recurring": true,
+  "createdAt": "ISO 8601",
+  "expiresAt": "ISO 8601 | null",
+  "lastFiredAt": "ISO 8601 | null",
+  "targetMs": 1234567890
+}
+```
+
+**Atomic writes:** `ScheduleStore.save()` writes to a temp file with PID+UUID suffix, then renames into place to avoid concurrent-write collisions.
+
+**Chat migration:** `moveForChat(fromChatId, toChatId)` renames all job files and rewrites the `chatId` field inside each, with collision detection to prevent silent jobId loss.
+
+### Observable surface
+
+**Tools exposed:**
+- `dc_schedule(chat_id, cron, prompt, recurring?, expires_at?)` — Create a job. Returns `{job_id, next_fire_at, warning?}`. Warning issued if >30 fires in 7 days.
+- `dc_schedule_list(chat_id)` — List all jobs for a chat. Returns array of `{job_id, cron, prompt, recurring, next_fire_at, expires_at, created_at, last_fired_at}`.
+- `dc_schedule_delete(chat_id, job_id)` — Delete a job. Returns `{deleted: true|false}`.
+
+**Auth:** All three tools require `chat_id` parameter. Caller (subagent) must be bound to that chat or an error is returned. Enforced via `callerChatId` (per-socket binding) and `access.isAllowed()` check.
+
+**Dispatch format:** Scheduled prompts are injected as user messages with a synthetic header: `[dc chat_id=<id> event=scheduled job=<jobId>]\n<prompt>`.
+
+**Limits & constraints:**
+- Prompt max 4000 chars.
+- Cron validation via cron-parser; invalid expressions rejected at creation time.
+- `countFiresIn7Days()` caps at 10,000 iterations (pathological defense).
+- Missed fires (system downtime) are skipped, not retried.
+
+### Primary source files
+
+- `plugin/dispatcher/scheduler.ts` — In-process cron engine, Scheduler class, fire loop, rearm logic.
+- `plugin/dispatcher/schedule-store.ts` — ScheduleStore class, per-job JSON files, `moveForChat`, atomic writes.
+- `plugin/server.ts` — Tool registration and dispatch (tool schemas and handler wiring).
+
+### Audit notes
+
+Jobs do not themselves generate audit entries. However, the dispatched prompt text is treated as a regular user message and subject to skip-permissions auto-approve logic if the agent has `x-dc-skipPermissions` set. Each tool call made during that turn will be audited normally. The `[dc chat_id=... event=scheduled job=...]` header is visible in the prompt for later reconstruction of intent.

--- a/docs/spec/skip-permissions-audit.md
+++ b/docs/spec/skip-permissions-audit.md
@@ -1,0 +1,76 @@
+# Skip-Permissions + Audit Log
+
+## Feature: Skip-permissions + audit log
+
+### Intended behavior
+
+When a chat is bound to an agent whose metadata includes `x-dc-skipPermissions: true`, the dispatcher auto-approves all tool calls made by that subagent and appends an audit entry instead of showing the WebXDC permission card. This enables unattended execution while maintaining a reviewable log of all auto-approved actions.
+
+Each tool call appended to the audit log includes the timestamp, agent ID, tool name, and a JSON snapshot of the input (truncated at 1000 characters to avoid bloat). The audit file is stored per-chat in markdown format, rendered by the file-reviewer WebXDC app via `dc_show_audit` tool.
+
+### State machine / transitions
+
+- **Check skip-permissions flag** — On permission request, `tryAutoApprove()` queries the agent metadata for `x-dc-skipPermissions` (via `getSkipPermissions()`).
+- **No flag** — Returns null; caller falls through to normal WebXDC permission card.
+- **Flag present** — Append audit entry via `audit.appendEntry()`, then immediately return `{kind: 'permissionVerdict', id, verdict: 'allow'}`.
+- **Audit write** — `appendEntry()` creates audit directory if needed, checks if file exists. If first entry, prepend header (chat ID + description). Append rendered entry (timestamp, agent ID, tool name, JSON input). Append-only, no rotation.
+- **User review** — User calls `dc_show_audit(chat_id)` to fetch the audit file and render it in the file-reviewer app.
+
+### Persisted state
+
+**Audit file location:** `~/.claude/channels/deltachat/audit/<chatId>.md` (one per chat).
+
+**Format:** Markdown, append-only.
+```markdown
+# Audit log for chat <chatId>
+
+Auto-approved tool calls for agents running in skip-permissions mode.
+
+## <ISO 8601 timestamp> — `<tool_name>`
+_agent: <agentId>_
+
+```json
+{...input JSON, max 1000 chars, truncated with … if longer...}
+```
+
+## <next timestamp> — `<tool_name>`
+...
+```
+
+**Header:** Written once on first append. Reused on subsequent appends (checked via `existsSync`).
+
+**Input truncation:** `MAX_INPUT_CHARS = 1000`. Inputs longer than this are `JSON.stringify`'d, truncated to first 1000 chars, and appended with `…`.
+
+### Observable surface
+
+**Agent metadata flag:** `x-dc-skipPermissions: true` (boolean) in agent definition's metadata bag.
+
+**Metadata read:** `getSkipPermissions(agent)` returns boolean (true if flag is set, false otherwise).
+
+**Tool:** `dc_show_audit(chat_id)` — Sends the audit file via file-reviewer. Returns success message or error if file does not exist / file-reviewer fails.
+
+**Audit entry interface:** `{ chatId, agentId, tool, input, timestamp: ISO 8601 }`.
+
+**Directory override (test):** `setAuditDir(dir)` for tests.
+
+**File-path queries:**
+- `auditFilePath(chatId)` — Always returns path (whether or not file exists).
+- `auditFilePathIfExists(chatId)` — Returns path only if file exists, else null.
+
+### Primary source files
+
+- `plugin/dispatcher/skip-permissions.ts` — `tryAutoApprove()` entry point; checks flag, appends audit, returns verdict.
+- `plugin/audit.ts` — Audit log management: `appendEntry`, `renderEntry`, `auditFilePath`, header logic.
+- `plugin/agents.ts` — `getSkipPermissions()` helper.
+- `plugin/server.ts` — Integration: `tryAutoApprove()` called on permission requests (socket-server glue).
+- `plugin/test/skip-permissions.test.ts` — Unit tests with injected `now()` for deterministic timestamps.
+
+### Audit notes
+
+Audit entries are created only for **allowed** tool calls. Denied calls (user rejects permission card, or tool is not in the agent's allowlist) do not appear in the audit log — they surface as `permission_denial` frames and are not auto-executed.
+
+The audit log is **append-only with no cleanup**: it grows indefinitely unless manually deleted. Long-running agents in skip-permissions mode may accumulate large audit files. Consider periodic archival/rotation if needed.
+
+**Interaction with tool allowlisting:** If both skip-permissions and per-agent tool restrictions are active, denied tools are filtered by the harness before the permission handler runs. Only allowed tools reach the auto-approve check, so the audit log contains only the subset of tools the agent is permitted to use.
+
+**Privacy:** The input parameter snapshot is stored in plaintext. Sensitive data (API keys, passwords, PII) may appear in the audit log if passed as tool input. No encryption or redaction is applied.

--- a/docs/spec/stt.md
+++ b/docs/spec/stt.md
@@ -1,0 +1,65 @@
+# Voice Transcription
+
+## Feature: Voice transcription
+
+### Intended behavior
+
+The plugin intercepts voice messages (Delta Chat `.m4a` files with `viewType='Voice'`) and transcribes them offline using `@napi-rs/whisper` (native bindings to whisper.cpp). Transcription runs in a dedicated Worker thread to avoid blocking the event loop during the heavy `whisper.full()` inference call.
+
+On successful transcription, the plaintext is prepended to the user's message as `[Voice transcript]: <text>`. In `echo=quoted` mode, the transcript is echoed back to the chat with a 🎙️ reaction; in `echo=silent` mode, it is transcribed but not shown. Sub-0.5-second clips are silently dropped (audio too short). Transcription is enabled/disabled via `DC_STT_ENABLED` environment variable.
+
+### State machine / transitions
+
+- **Detect** — `runSubagentTurn()` checks if message is voice (`viewType=Voice` + file path). If not, passes through unchanged.
+- **Bootstrap gate** — Waits for bootstrap readiness (native module install must complete). Returns null on timeout (proceeds with untranscribed message).
+- **Model download** — `ensureModel()` checks if whisper model file exists on disk. If not, downloads from Hugging Face, verifies SHA-256 against pinned hash from `whisper-model-hashes.json`, and atomically renames into `~/.claude/channels/deltachat/whisper-models/`.
+- **Reaction: listening** — Sends 👂 reaction to user's message while loading model/starting transcription.
+- **Decode** — Synchronously on main thread: `@napi-rs/whisper.decodeAudio()` parses `.m4a` (via Symphonia codec) into Float32Array samples, calculates duration (samples / 16000 Hz).
+- **Duration checks** — If < 0.5s, throw `AudioTooShortError` (dropped silently). If > `maxDurationSec`, reject. Otherwise proceed to Worker.
+- **Worker dispatch** — Post message to `stt-worker.ts` with `{ id, filePath, modelPath, modelName, maxDurationSec }`. Worker caches the Whisper instance per modelPath.
+- **Transcription** — `Whisper.full()` on Float32Array, collect segments via `onNewSegment` callback. Language=`en` for `.en` models, `auto` (detect + transcribe) for multilingual models.
+- **Echo** — If `echo=quoted`, send transcript to chat with 🎙️ reaction + thinking emoji.
+- **Enrich message** — Return message object with text prepended: `[Voice transcript]: ${result.text}${original.text}`.
+- **Timeout** — If Worker transcription exceeds `timeoutSec`, terminate Worker and reject with timeout error. Caller logs and proceeds with original message.
+
+### Persisted state
+
+**Model cache:** `~/.claude/channels/deltachat/whisper-models/ggml-<model>.bin` (downloaded once per model, shared across chats).
+
+**Hash pinning:** `plugin/whisper-model-hashes.json` — JSON map of model names to expected SHA-256 hashes. Sourced from Hugging Face LFS metadata. Forward-compatible: if a model is unpinned, download is accepted with a warning.
+
+**Worker state:** Single global Worker instance (lazy-init in `getWorker()`). Caches a single Whisper instance (in-memory) per modelPath to avoid reload cost. Resets on error.
+
+### Observable surface
+
+**Environment variables:**
+- `DC_STT_ENABLED` — (default: `true`) Disable STT if set to `false` (case-insensitive).
+- `DC_STT_MODEL` — (default: `base.en`) Model size/language: `tiny.en`, `base.en`, `base`, `small`, `medium`, `large`, etc.
+- `DC_STT_ECHO` — (default: `quoted`) `quoted` = echo transcript back to chat; `silent` = transcribe but don't echo.
+- `DC_STT_TIMEOUT_SEC` — (default: `120`) Transcription wall-clock timeout.
+- `DC_STT_MAX_DURATION_SEC` — (default: `300`) Reject audio longer than this.
+- `DC_STATE_DIR` — (default: `~/.claude/channels/deltachat`) Base directory for whisper-models cache.
+
+**Config parsing:** `parseSTTConfig(env)` validates and returns STTConfig struct with defaults.
+
+**Constants:**
+- `MIN_AUDIO_DURATION_SEC = 0.5` — Clips shorter than this throw `AudioTooShortError` and are silently dropped.
+
+**Reactions:**
+- 👂 during decode/model-download phase.
+- 🎙️ on the echoed transcript message (echo=quoted mode only).
+- 🤏 (pinched hand) on the original voice message if dropped for being too short.
+
+**Interception point:** `tryTranscribeVoice()` called from `runSubagentTurn()` before subagent dispatch.
+
+### Primary source files
+
+- `plugin/stt.ts` — Main transcription API: `parseSTTConfig`, `ensureModel`, `transcribe`, `isVoiceMessage`, `AudioTooShortError`, Worker pool.
+- `plugin/stt-worker.ts` — Worker thread handler; owns cached Whisper instance; calls `whisper.full()` with language detection.
+- `plugin/server.ts` — `tryTranscribeVoice` integration in `runSubagentTurn`.
+- `plugin/whisper-model-hashes.json` — Pinned SHA-256 hashes for supported models.
+- `plugin/package.json` — Dependency on `@napi-rs/whisper`.
+
+### Audit notes
+
+Voice transcription is a pre-processing step; it does not itself call tools. The enriched message (with `[Voice transcript]:` prefix) is passed to the subagent. Any subsequent tool calls made during the turn are audited normally if skip-permissions is enabled. The transcript is visible in the turn history and reconstructable from chat export.

--- a/docs/spec/subagent-lifecycle.md
+++ b/docs/spec/subagent-lifecycle.md
@@ -1,0 +1,218 @@
+# Subagent Lifecycle + Dispatcher Internals
+
+## Feature: Subagent lifecycle + dispatcher internals
+
+### Intended behavior
+
+**Subagent spawning and lifecycle:**
+- One persistent `claude -p` process per chat, spawned on demand by the dispatcher when a message arrives.
+- First spawn creates a new session (UUID + `--session-id` flag); subsequent spawns on the same chat reuse the UUID with `--resume` to rehydrate turn history.
+- Subagents communicate with the dispatcher via Unix socket using newline-delimited JSON; each connection authenticates with a shared secret and identifies its role (`tools` or `hook`).
+- Subagent stdout is consumed as stream-json frames; the dispatcher watches for `type: 'result'` frames to complete a turn.
+- Permission requests are serialized through a PreToolUse hook script that relays to the dispatcher's socket server and blocks awaiting a verdict.
+- DC tool calls flow back to the dispatcher via a spawned MCP server (`tools-proxy.ts`) that forwards each CallTool request to the socket server.
+
+**Cache and eviction:**
+- An LRU cache holds up to `DC_SUBAGENT_MAX_ACTIVE` (default 8) active subagents; when at capacity, the least-recently-used chat's subagent is evicted.
+- Each cached subagent has an idle timeout (`DC_SUBAGENT_IDLE_MIN`, default 480s); after idle timeout, it is closed and removed from the cache.
+- Queue depth per chat is capped at `DC_SUBAGENT_QUEUE_MAX` (default 10); overflowing messages drop the oldest queued message.
+- Crash detection: if a subagent is found dead between turns (`alive=false`), it is evicted and a callback fires (used for cleanup/logging).
+- Pre-warming: `cache.prewarm(chatId)` spawns a subagent without sending a turn, used at pairing time to pay the cold-spawn cost upfront.
+
+**Permission round-trip:**
+- When Claude attempts a gated tool (Bash, Edit, Write, WebFetch, WebSearch, NotebookEdit), the PreToolUse hook fires.
+- Hook script reads the tool payload from stdin, fast-paths auto-allow for safe read-only Bash commands (date, pwd, whoami, uname), then delegates to `permission-hook-client.ts`.
+- Client helper connects to the dispatcher's Unix socket, sends `permissionRequest` frame with the tool name and input, and blocks on `permissionVerdict`.
+- Dispatcher routes the request to a permission handler which either auto-approves (skip-permissions agent) or shows a WebXDC permission card to the user.
+- Verdict flows back to the hook client on the same connection; hook exits 0 (allow) or 2 (deny), forwarding the user's choice back to Claude.
+
+**Observable tool calls:**
+- All tool calls from DC go through the tools-proxy MCP server, which forwards them to the dispatcher's socket server as `toolCall` frames.
+- The dispatcher executes the tool (delegating most to the DC client or legacy code paths) and returns a `toolResult` frame with the result or a `toolError` frame if anything fails.
+- Activity reactions are emitted for tool use (reading emoji for Read/Grep, coding emoji for Edit/Write, etc.); a random thinking emoji fires at turn start before any tool.
+
+### State machine / transitions
+
+**Subagent states:**
+- **Cold**: Chat has never been used, or the subagent was evicted. No process exists.
+- **Spawning**: A subagent process is starting (`spawn()` call in progress). Still no process assigned to cache yet.
+- **Active**: Subagent process is alive, cached, and ready. `lastUsed` is updated on every touch. Idle timer is reset on every dispatch or touch.
+- **Idle**: Subagent exists in cache but no turn has arrived for `idleTimeoutMs`. Idle timer expires → `evict()` fires.
+- **Busy**: Subagent is currently processing a turn (`busy=true`). Additional incoming turns queue. Queued turns execute sequentially via `runOrQueue()` → `runNow()`.
+- **Evicted**: Subagent was removed from cache (LRU eviction, idle timeout, or crash detected). Process is closed. Any queued work is failed with "subagent evicted" error.
+- **Crashed**: Process died unexpectedly (detected when `alive=false` after a send attempt or between turns). Evict and fire `onCrash()` callback.
+
+**Permission request states:**
+- **Sent**: Hook client sends `permissionRequest` frame to dispatcher socket server.
+- **Pending-verdict**: Dispatcher's socket server queues the request for the user (WebXDC card) or auto-approves (skip-permissions). Hook client waits on socket.
+- **Approved**: Dispatcher sends `permissionVerdict` with `verdict='allow'`. Hook exits 0. Claude proceeds with the tool.
+- **Denied**: Dispatcher sends `permissionVerdict` with `verdict='deny'`. Hook exits 2, printing deny reason to stderr. Claude sees the denial.
+- **Timeout**: Hook's timeout (default 300s, `DC_HOOK_TIMEOUT_SEC`) expires. Shell wrapper exits 2. Treated as denial.
+
+### Persisted state
+
+**Subagent-side persisted state:**
+- Per-subagent session UUID (stable across restarts of the same chat). Stored in bindings; passed to subagent on spawn.
+- Per-subagent `settings.json` file (temp directory, cleaned up on subagent close) containing PreToolUse hook config and gated tool list.
+- Per-subagent `mcp-config.json` (temp directory) pointing to tools-proxy and tools manifest.
+- Turn history is stored in-process by Claude Code (`-p` mode); when a subagent is resumed, the prior history is rehydrated.
+
+**Dispatcher-side persisted state:**
+- Rate limit bucket timestamps (`RateLimiter`) for each chat, survives subagent respawn so a crash loop cannot refill the budget.
+- Scheduled jobs store (see `scheduling.md`) in `~/.claude/channels/deltachat/schedules/`.
+- Audit log (`~/.claude/channels/deltachat/audit/<chatId>.md`) records tool calls when skip-permissions is enabled (see `skip-permissions-audit.md`).
+- Debug log (`~/.claude/channels/deltachat/debug.log`) for troubleshooting.
+
+**Environment variables (set by dispatcher on spawn):**
+- `DC_DISPATCHER_SOCKET`: Absolute path to Unix socket the subagent connects back to.
+- `DC_DISPATCHER_SECRET`: 32-byte hex string for socket authentication (random per dispatcher startup).
+- `DC_SUBAGENT_ID`: Unique subagent id (random UUID), used in socket hello and for registry lookup.
+- `DC_SUBAGENT_CHAT_ID`: The chat id this subagent is bound to (integer). Enforced at socket boundary.
+- `DC_HOOK_TIMEOUT_SEC`: Max seconds to wait for permission verdict (default 300).
+- `DC_TOOLS_MANIFEST`: Path to JSON array of tool definitions (name, description, inputSchema) exposed by tools-proxy.
+
+**Dispatcher-controlled environment variables (read from process.env or .env file):**
+- `DC_SUBAGENT_MAX_ACTIVE`: Max concurrent cached subagents (default 8, min 1, max 16).
+- `DC_SUBAGENT_IDLE_MIN`: Idle timeout in minutes (default 480 = 8 hours).
+- `DC_SUBAGENT_TURN_TIMEOUT_MIN`: Max turn duration in minutes (default 60).
+- `DC_SUBAGENT_QUEUE_MAX`: Max queued prompts per chat (default 10, min 1, max 1000).
+- `DC_SUBAGENT_RATE_LIMIT`: Max tool calls per chat per window (default 100, min 1, max 10000).
+
+### Observable surface
+
+**Unix socket path and frame types:**
+
+Socket path: `~/.claude/channels/deltachat/dispatcher.sock` (mode 0o600)
+
+Frame format: Newline-delimited JSON, Zod-validated at boundary.
+
+**Client → Server frames:**
+- `hello`: `{ kind: 'hello', secret: string, role: 'tools'|'hook', chatId: number, subagentId: string }`. Must be first frame on any connection.
+- `toolCall`: `{ kind: 'toolCall', id: string, tool: string, args: object }`. Only from tools-proxy (`role='tools'`).
+- `permissionRequest`: `{ kind: 'permissionRequest', id: string, tool: string, input: unknown }`. Only from hook (`role='hook'`).
+- `bye`: `{ kind: 'bye' }`. Graceful close signal.
+
+**Server → Client frames:**
+- `helloAck`: `{ kind: 'helloAck' }`. Response to successful hello.
+- `toolResult`: `{ kind: 'toolResult', id: string, result: { content: [...], isError?: boolean } }`. Response to `toolCall`.
+- `toolError`: `{ kind: 'toolError', id: string, error: { code: string, message: string } }`. Error response to `toolCall` or bad hello.
+- `permissionVerdict`: `{ kind: 'permissionVerdict', id: string, verdict: 'allow'|'deny', message?: string }`. Response to `permissionRequest`.
+
+**Permission hook execution:**
+- Shell wrapper (`permission-hook.sh`) handles timeout (default 300s), fast-path auto-allow for safe Bash commands, and error translation (exit 2 = deny).
+- Bun client (`permission-hook-client.ts`) handles socket I/O and frame marshaling. Exit codes: 0 = success, non-zero = failure (treated as deny).
+- Hook is invoked by Claude Code PreToolUse mechanism; input is JSON on stdin, output is "allow" or "deny: <message>" on stdout, exit code to Claude.
+
+**Activity reactions (emoji contract):**
+- Reaction is tied to the user's turn message ID, set at turn start by `setTurnTarget(msgId)` which emits a random thinking emoji.
+- `reactForTool(toolName, toolInput)` maps tool classes to emoji pools:
+  - `coding` (Edit/Write) → ✏️/🎨
+  - `reading` (Read/Grep) → 🔍/👀
+  - `running` (Bash) → ⚙️/🔧
+  - `planning` (EnterPlanMode) → ✍️/🗺️
+  - `delegating` (Task) → 🤝
+  - `todo-*` → keycap/regional indicator
+- Emojis are debounced by class; if the last tool was also coding, the same message ID gets no new reaction.
+- `clearTurnTarget(chatId)` drops state at turn end (emoji remains visible).
+
+**Subagent stdout/stderr handling:**
+- Stdout is parsed as newline-delimited JSON stream frames. Frames are buffered and matched against predicates (e.g., `f.type === 'result'`). Unmatched frames are re-queued.
+- Stderr lines are logged to debug.log with subagent id prefix. No automatic error handling; stderr does not cause turn failure.
+- Turn timeout is enforced by `readFrame(predicate, timeoutMs)`, which polls the deadline and re-arms if extended by `extendDeadline()` (used to pause timeout during permission prompts).
+
+### Primary source files
+
+| File | Purpose |
+|------|---------|
+| `plugin/dispatcher/subagent-cache.ts` | LRU cache of active subagents per chat; spawn-on-demand, idle timeout, eviction, queue depth, crash detection. |
+| `plugin/dispatcher/subagent-process.ts` | Wraps `claude -p` child process; stream-json I/O, stdin writes, stdout frame parsing, turn timeout with deadline extension. |
+| `plugin/dispatcher/socket-server.ts` | Unix socket listener; hello frame auth (secret + subagentId + chatId validation), connection routing, out-of-band frame delivery. |
+| `plugin/dispatcher/permission-hook.sh` | PreToolUse shell wrapper; timeout handling, fast-path for safe Bash, error translation (exit 2 = deny). |
+| `plugin/dispatcher/permission-hook-client.ts` | Bun helper spawned by hook.sh; socket I/O, hello + `permissionRequest` / `permissionVerdict` frame exchange. |
+| `plugin/dispatcher/hook-config.ts` | Generates per-subagent `settings.json` with PreToolUse hooks and per-subagent `mcp-config.json` with tools-proxy. |
+| `plugin/dispatcher/tools-proxy.ts` | Per-subagent MCP server; loads tool manifest, listens for CallTool, forwards to dispatcher socket as `toolCall` frames, maps `toolResult`/`toolError` responses. |
+| `plugin/dispatcher/message-router.ts` | Classifies Delta Chat events; system vs. user messages, paired vs. unpaired, authorized vs. unauthorized. Routes to cache or legacy paths. |
+| `plugin/dispatcher/reaction-router.ts` | Buffers and debounces emoji reactions; checks allowlist, owner, and live-subagent status; dispatches synthetic user turns. |
+| `plugin/dispatcher/activity-reactions.ts` | Emoji pool selection by tool class; thinking emoji at turn start; deduping by class. |
+| `plugin/dispatcher/rate-limit.ts` | Per-chat sliding-window token bucket for tool-proxy calls; survives subagent respawn. |
+| `plugin/dispatcher/skip-permissions.ts` | Auto-approve path for skip-permissions agents; see `skip-permissions-audit.md`. |
+| `plugin/dispatcher/orphan-cleanup.ts` | Dispatcher startup sweep for stale `claude -p` processes from prior crashed dispatcher (Linux/macOS only). |
+
+### Audit notes
+
+**Races and concurrency concerns:**
+
+1. **Cache eviction during active permission hook** (`subagent-cache.ts`, `subagent-process.ts`):
+   - If a hook request is in flight and the LRU cache evicts the subagent's entry, the hook client may attempt to write to a closed socket or receive no verdict. The hook's timeout (300s default) will trigger and exit 2, but the user sees a denial instead of a clean cancellation.
+   - Root cause: socket-server does not track which hook connection maps to which chat entry.
+   - Mitigation: `extendDeadline()` can be called to pause the turn timeout, but this only extends the subagent-side deadline, not the hook-side timeout.
+
+2. **Queue overflow drops during active turn** (`subagent-cache.ts`):
+   - If `entry.busy` is true and the queue is at max, the oldest queued message is dropped with "queue overflow". If that message is a critical system message (e.g., user cancels), it is silently lost.
+   - No priority mechanism for retrying or replaying dropped messages.
+
+3. **Crash detection race** (`subagent-process.ts`, `subagent-cache.ts`):
+   - If a subagent dies mid-turn, `entry.sub.alive` becomes false. The `send()` catches this and calls `onCrash()`. However, if the cache is simultaneously evicted (LRU or timeout), `evict()` also calls `close()` without checking alive.
+   - No double-close guard; if two code paths race to close the same process, the second gets an error (caught, but noisy logging).
+
+4. **Socket authorization at chat_id boundary** (`socket-server.ts`, `tools-proxy.ts`):
+   - When hello arrives, the dispatcher verifies that the subagentId maps to the correct chatId. However, if the binding registry is updated (agent re-paired, chat reassigned) AFTER hello but BEFORE the tool call, the tool executes with stale authorization.
+   - The tools-proxy embeds chatId in every `toolCall` frame, but the dispatcher only validates it once at hello. No re-check per frame.
+
+**Silent failure modes:**
+
+5. **Hook client socket errors exit non-zero but hook.sh translates them to deny** (`permission-hook-client.ts`, `permission-hook.sh`):
+   - Socket errors (connect failed, frame parse failure) are caught and exit non-zero. The shell wrapper treats any non-zero as a timeout/error and exits 2 (deny).
+   - User sees "permission relay timed out" even if the socket error was "dispatcher not running" or "secret mismatch". Root cause buried in stderr.
+   - Recommendation: structured error codes so logs can distinguish socket vs. timeout vs. verdict errors.
+
+6. **Subagent spawn failures not retried** (`subagent-cache.ts`):
+   - If `spawnFn()` returns null (no agent bound to chat), dispatch fails with "subagent spawn skipped (no agent bound)". No fallback; the message is lost from the subagent's perspective.
+
+7. **Frame queue predicate mismatch silences frames** (`subagent-process.ts`):
+   - If a frame arrives that doesn't match the current predicate, it is pushed back onto `frameQueue` and the waiter is re-added. However, if the waiter times out while the frame is buffered, the frame is orphaned forever.
+   - No garbage collection of orphaned frames or waiters; `frameQueue` can grow unbounded.
+
+8. **Message router doesn't inform unauthorized senders** (`message-router.ts`):
+   - Unauthorized senders (paired chat but not owner) are silently ignored with a log line. No feedback to the user.
+   - Contrasts with unpaired chats, which trigger the pairing flow.
+
+9. **Reaction dispatch fires asynchronously and failures are swallowed** (`activity-reactions.ts`):
+   - `reactForTool()` is fire-and-forget; if the DC reaction RPC fails, the turn continues unaffected.
+
+10. **Rate limiter doesn't inform user of rate-limit hit** (`rate-limit.ts`, `server.ts`):
+    - Returns boolean; dispatcher logs and drops the tool call, but no message to Claude saying "rate limit exceeded, tool denied."
+    - Recommendation: return a structured error.
+
+**Orphaned code or inconsistencies:**
+
+11. **`suppressUserClaudeMd` deferred to Phase 2** (`subagent-process.ts`):
+    - Flag is parsed and logged but ignored. No-op. Needs a `--no-user-claude-md` or similar flag in Claude Code.
+
+12. **Reaction router buffers but does not persist** (`reaction-router.ts`):
+    - Buffered reactions are lost if the dispatcher crashes between buffer and flush.
+
+13. **Orphan cleanup skips live subagents owned by sibling dispatchers** (`orphan-cleanup.ts`):
+    - Two dispatchers starting concurrently will each skip the other's subagents (ppid != 1). If the sibling crashes after killing children, the new dispatcher will see ppid=init and kill them. No PID lockfile prevents this race.
+
+14. **Pre-warm entry point not discoverable** (`subagent-cache.ts`):
+    - `cache.prewarm(chatId)` is public but may not be exposed by server.ts; dead code if no caller.
+
+**Configuration inconsistencies:**
+
+15. **`DEFAULT_GATED_TOOLS` hard-coded** (`hook-config.ts`):
+    - Default is `['Bash', 'Edit', 'Write', 'NotebookEdit', 'WebFetch', 'WebSearch']`. No env/config override.
+
+16. **`KNOWN_MCP_SERVERS` is a fixed map** (`subagent-process.ts`):
+    - MCP servers are hard-coded. Per-subagent `allowedMcpServers` can restrict but cannot expand.
+
+**Missing observability:**
+
+17. **No histogram for turn latency** (`subagent-process.ts`):
+    - Turn times are logged (`durationMs` in `resultFrame`) but not exported or aggregated. No p50/p99 metrics.
+
+18. **No metrics for cache hit/miss ratio** (`subagent-cache.ts`):
+    - `hasLive()` is not instrumented. No visibility into cold-spawn frequency.
+
+19. **Queue drop callback is best-effort** (`subagent-cache.ts`):
+    - `onQueueDrop()` may throw and is caught silently.

--- a/docs/spec/tool-allowlisting.md
+++ b/docs/spec/tool-allowlisting.md
@@ -1,0 +1,75 @@
+# Per-Agent Tool Allowlisting
+
+## Feature: Per-agent tool allowlisting
+
+### Intended behavior
+
+Each agent definition can restrict which built-in tools and MCP servers its subagent is allowed to use. Built-in tools (Bash, Read, Edit, Grep, LSP, etc.) have per-tool granularity; MCP servers (Gmail, Google Calendar, Slack, Notion, Asana, Telegram, DC Tools) are all-or-nothing toggles per server prefix.
+
+When an agent is spawned, the allowlist is encoded in the `--allowedTools` CLI flag passed to the `claude` child process. Restrictions are enforced by the Claude Code harness at tool-invocation time — denied tools return `permission_denial` frames rather than executing.
+
+If `allowedBuiltinTools` or `allowedMcpServers` are `null` or absent from the agent definition, all tools/servers are allowed (permissive default). An empty array `[]` denies all access to that category.
+
+### State machine / transitions
+
+- **Agent definition** — YAML file on disk includes optional `allowedBuiltinTools: [...]` and `allowedMcpServers: [...]` arrays (nullable).
+- **Validation** — Agent schema (Zod) accepts both fields as optional nullable arrays of strings.
+- **Migration** — Legacy `allowedMcpTools` (per-tool names) is migrated to `allowedMcpServers` (per-server prefixes) on load via `migrateToolsToServers()`.
+- **Subagent spawn** — `buildSubagentArgs()` constructs `--allowedTools` flag: space-separated list of tool names prefixed with `mcp__` for servers (e.g. `mcp__dc mcp__claude_ai_Gmail Bash Read`). Defaults: all builtin tools + all known server prefixes.
+- **UI exposure** — Agent-setup WebXDC app queries available tools via `availableToolsPayload()`, which loads `ALL_BUILTIN_TOOLS` and `KNOWN_MCP_SERVERS`. The UI renders checkboxes for builtins and toggles for servers. User selection updates `agent.allowedBuiltinTools` / `agent.allowedMcpServers` before `saveAgent()`.
+- **Enforcement** — Claude Code harness (hook-config / subagent-process) filters available tools at spawn time and rejects denied tool calls with `permission_denial`.
+
+### Persisted state
+
+**Agent definition:** `~/.claude/channels/deltachat/agents/<agentId>.yaml`
+
+**Schema fields:**
+```yaml
+allowedBuiltinTools: [string] | null  # null/absent = all allowed
+allowedMcpServers: [string] | null    # null/absent = all allowed
+```
+
+**Migration field (deprecated):**
+```yaml
+allowedMcpTools: [string] | null  # migrated → allowedMcpServers on read
+```
+
+### Observable surface
+
+**Built-in tools constant:** `ALL_BUILTIN_TOOLS` (`plugin/dispatcher/subagent-process.ts`):
+- Bash, Read, Edit, Write, Grep, Glob
+- WebFetch, WebSearch, NotebookEdit
+- Task, TaskOutput, TaskStop, TodoWrite
+- Skill, ToolSearch
+- AskUserQuestion, LSP
+- EnterPlanMode, ExitPlanMode, EnterWorktree, ExitWorktree
+
+**MCP servers constant:** `KNOWN_MCP_SERVERS` (`plugin/dispatcher/subagent-process.ts`):
+```
+dc                          → 'DC Tools'
+claude_ai_Gmail             → 'Gmail'
+claude_ai_Google_Calendar   → 'Google Calendar'
+claude_ai_Slack             → 'Slack'
+claude_ai_Notion            → 'Notion'
+claude_ai_Asana             → 'Asana'
+plugin_telegram_telegram    → 'Telegram'
+```
+
+**Tool descriptions:** `BUILTIN_TOOL_DESCRIPTIONS` (`subagent-process.ts`) — short text for each built-in tool, used by the UI.
+
+**CLI flag format:** `--allowedTools "mcp__<prefix> <prefix> ... <builtin> <builtin> ..."`. If an MCP server prefix is passed but the server is not available, Claude Code silently ignores it (no error).
+
+**Agent-setup UI:** `availableMcpServers` / `connectedMcpServers` split — "available" are all known servers; "connected" are those that have completed OAuth auth. UI shows toggles for available servers.
+
+### Primary source files
+
+- `plugin/agents.ts` — `AgentDefSchema` with `allowedBuiltinTools` / `allowedMcpServers` / legacy `allowedMcpTools`; `migrateToolsToServers()` migration logic.
+- `plugin/dispatcher/subagent-process.ts` — `ALL_BUILTIN_TOOLS`, `BUILTIN_TOOL_DESCRIPTIONS`, `KNOWN_MCP_SERVERS` constants; `buildSubagentArgs()` CLI flag generation.
+- `plugin/apps/agent-setup-app.ts` — `availableToolsPayload()`, UI rendering of tool picker.
+- `plugin/server.ts` — `getAvailableMcpServers()`, `getConnectedMcpServers()` context methods.
+
+### Audit notes
+
+Tool allowlisting is a deployment-time constraint. It does not affect skip-permissions audit logging — if both allowlisting and skip-permissions are active, denied tools are filtered at the harness level before reaching the dispatcher, so they never generate audit entries. Allowed tools are auto-approved and audited normally.
+
+The interaction is transparent: if a user restricts an agent's tools and enables skip-permissions, only the allowed subset can auto-execute. Tool denials still surface as `permission_denial` frames to the user, consistent with the normal flow.

--- a/docs/spec/webxdc-apps.md
+++ b/docs/spec/webxdc-apps.md
@@ -1,0 +1,269 @@
+# WebXDC Apps + Familiar Runtime
+
+## Feature: WebXDC apps + Familiar runtime
+
+### Intended behavior
+
+dc-claude-channel provides a plugin system for WebXDC apps — interactive cards sent to Delta Chat chats — plus a lightweight Familiar runtime for building server-side interactive apps at runtime.
+
+**Per-app user experience:**
+- User triggers an MCP tool (e.g., `dc_send_file`, `dc_send_slides`, `dc_familiar_create`).
+- App sends a `.xdc` file to the chat; Delta Chat renders it as a tappable card.
+- User taps the card or interacts with it (fills form, clicks button, leaves comment).
+- WebXDC update arrives at the server via Delta Chat's update-streaming API.
+- Server verifies the update came from the chat owner (owner verification).
+- If valid, the update is dispatched to the app's `onWebXDCUpdate` handler.
+- Handler processes the update (e.g., file-reviewer logs comments; familiar runs handler JS in sandbox).
+- Handler may call `sendUpdate()` to push new payloads back to the app.
+- User sees live updates on the card in real time.
+
+**Auto-upgrade protocol:** When the server builds a new `.xdc` with a higher `APP_VERSION`, the old app detects the version mismatch via update payload inspection, sends a `version_mismatch` signal, and the server rebuilds and re-sends the app to the chat. The user swipes back to the chat and taps the updated card.
+
+**Familiar apps (runtime-authored interactive logic):**
+- Claude authors a short JS handler string (e.g., for a counter, poll, or stateful workflow).
+- Handler runs in a restricted eval sandbox; can access `ctx.state` (persistent state), `ctx.sendUpdate()` (push to app), `ctx.requestLLM()` (call the LLM).
+- No Node/Bun/Deno globals; standard JS builtins (JSON, Math, Date, etc.) available.
+- User review/approval gates execution (primary security model).
+
+### State machine / transitions
+
+**Per-app session lifecycle:**
+
+1. **Created:** Tool calls (e.g., `dc_send_file`, `dc_familiar_create`) build a `.xdc` file and send it to a chat.
+   - Permissions app: on first request to a chat, build and send `.xdc` (msgId stored in `permissionsSessions` map).
+   - File reviewer: on first file to a chat, build and send `.xdc` (msgId stored in `activeViewers` map).
+   - Agent setup: on first `dc_open_agent_settings` call, build and send `.xdc` (msgId stored in `agent-setup-sessions.json` on disk).
+   - Familiar: each `dc_familiar_create` generates a unique `appId`, builds `.xdc`, sends to chat; instance registered in `byAppId` + `byMsgId` maps.
+
+2. **Registered:** App msgId is registered in `webxdcAppRegistry` (msgId → {app, chatId}) for event-driven dispatch.
+
+3. **Updates flowing:** WebXDC updates arrive via Delta Chat; server calls `app.onWebXDCUpdate(msgId, filteredUpdates, ctx)`.
+   - Serial tracking (`webxdcLastSerial` map) prevents replaying old updates after restart.
+   - Per-msgId handler chaining (`webxdcHandlerChain` map) serializes concurrent updates on the same app.
+
+4. **Version mismatch detected:** App sends `{type: 'version_mismatch', appVersion, serverVersion, senderAddr}`.
+   - Server unregisters old msgId from registry.
+   - Server rebuilds `.xdc` with fresh code from disk.
+   - Server clears old session state (e.g., permissions session, file-reviewer lastUpdate).
+   - Server sends new `.xdc` to the chat.
+   - Server re-registers new msgId in registry.
+   - User swipes back to chat and taps updated card; updates now flow to new msgId.
+
+5. **Cleared:** On chat unpair/deletion or explicit app delete:
+   - Permissions: delete entry in `permissionsSessions`.
+   - File reviewer: delete entry in `activeViewers`.
+   - Agent setup: delete entry in `agent-setup-sessions.json`.
+   - Familiar: call `deleteInstance(appId)` (both maps) + `deletePersistedInstance()` if persistent.
+   - Always: unregister msgId from `webxdcAppRegistry`.
+
+**Familiar app lifecycle (ephemeral vs persistent):**
+
+- **Ephemeral:** `persistent: false` (default). Instance lives in `byAppId` + `byMsgId` maps in-memory only. On server restart, instance is gone.
+- **Persistent:** `persistent: true`. Instance is written to `~/.claude/channels/deltachat/familiars/{appId}.json` after each state mutation. On server startup, `loadPersistedInstances()` reads all `.json` files and re-registers them.
+- **Lifecycle events:**
+  - Created: `dc_familiar_create` → build XDC → send to chat → register instance.
+  - Updated: `dc_familiar_update` → send payload to app → handler runs → state mutated.
+  - Deleted: `dc_familiar_delete` → unregister → delete persisted file.
+  - Reloaded on restart: server startup → `loadPersistedInstances()` → re-register all ephemeral+persistent instances in maps.
+
+### Persisted state
+
+**Prebuilt cache:**
+- Location: `plugin/webxdc-prebuilt/` directory.
+- Naming: `{html-filename}-v{version}.xdc`
+  - Example: `file-reviewer.html` at version 1.5 → `file-reviewer-v1.5.xdc`.
+- Lookup: `xdc-builder.ts` checks `prebuiltDir/{id}-v{version}.xdc` before building.
+- Bypass: Set `DC_SKIP_PREBUILT=1` environment variable to always build fresh.
+- Content: `.xdc` is a ZIP containing `index.html` (versioned), `manifest.toml` (name appended with `v{version}`), `icon.png` (optional).
+
+**Familiar persistence directory schema:**
+- Base: `~/.claude/channels/deltachat/familiars/`.
+- Per-instance: `{appId}.json` (one file per app instance).
+- Format: JSON with fields `appId`, `chatId`, `msgId`, `title`, `html`, `handler`, `state`, `persistent`, `createdAt`.
+- Write atomicity: Writes use `.tmp.{pid}.{uuid}` temp file, then atomic `rename` to avoid corruption on concurrent writes.
+- Load: On server startup, iterate files, parse JSON, validate required fields, skip invalid files.
+
+**Per-app session msgId tracking:**
+- **In-memory (`webxdcAppRegistry`):** `msgId → {app, chatId}` map used for event dispatch. Seeded at startup from persisted session files and re-seeded on version-mismatch upgrade.
+- **On disk (app-specific):**
+  - Agent setup: `~/.claude/channels/deltachat/agent-setup-sessions.json` — array of `{msgId, sourceChatId, lastSerial?}`.
+  - Permissions: In-memory only (`permissionsSessions` map); no persistence.
+  - File reviewer: In-memory only (`activeViewers` map); no persistence.
+  - Familiar: Persisted via each instance's `.json` file (msgId field in instance record).
+
+### Observable surface
+
+**Tools registered by each app:**
+
+1. **Permissions app** (`permissionsApp`):
+   - `dc_test_permission`: Test-only tool to simulate permission request.
+   - No production tool; permissions are triggered by dispatcher's internal MCP hooks.
+
+2. **File reviewer app** (`fileReviewerApp`):
+   - `dc_send_file(chat_id, title, content?, file_path?, language?)` — auth: `ctx.isAllowed(chat_id)`.
+   - `dc_send_slides(chat_id, title, content)` — thin alias that calls `dc_send_file` internally; viewer auto-detects Marp format.
+
+3. **Agent setup app** (`agentSetupApp`):
+   - `dc_open_agent_settings(chat_id)`
+   - `dc_open_agent_settings_no_resume(chat_id)`
+   - `dc_agent_action(chat_id, action, payload)`
+
+4. **Familiar app** (`familiarApp`):
+   - `dc_familiar_create(chat_id, title, html, handler, initial_state?, persistent?)`
+   - `dc_familiar_update(chat_id, app_id, payload)`
+   - `dc_familiar_list(chat_id)`
+   - `dc_familiar_delete(chat_id, app_id)`
+
+**WebXDC payload schemas:**
+
+All payloads must include `senderAddr: window.webxdc.selfAddr` (validated at server-side owner-verification filter; updates missing it are silently dropped in owned chats).
+
+*Common fields:*
+```
+{
+  payload: {
+    senderAddr: string          // REQUIRED in owned chats
+    [type: string]              // App-specific type (e.g., 'response', 'comments', 'request')
+    [version?: number]          // Optional; compared against APP_VERSION for auto-upgrade
+    ...rest
+  },
+  summary: string               // User-visible one-liner shown in chat
+  info?: string                 // Tappable notification text
+  href?: string                 // URL path within the app
+}
+```
+
+*Permission prompt payload:*
+```
+{type: 'request', version, requestId, toolName, description, inputPreview}
+{type: 'response', requestId, granted, senderAddr, senderName?}
+{type: 'version_mismatch', appVersion, serverVersion, senderAddr}
+{type: 'open_agent_settings', senderAddr, senderName?}
+```
+
+*File reviewer payload:*
+```
+{type: undefined, title, content, language?, version, startLine?}  // File/doc tab
+{type: 'comments', fileTitle?, language?, comments: [{line?, paragraph?, slide?, context?, comment?}]}
+{type: 'close_tab', title?, docIndex?}
+{type: 'version_mismatch', appVersion, serverVersion, senderAddr}
+```
+
+*Familiar payload (user-authored):*
+```
+Handler receives (update, ctx):
+  update = {senderAddr, ...user-defined fields}
+  ctx = {state: {}, sendUpdate, requestLLM, appId, chatId}
+Handler calls ctx.sendUpdate({senderAddr: window.webxdc.selfAddr, ...payload})
+```
+
+**Auto-upgrade handshake messages:**
+
+1. App detects mismatch (APP_VERSION in HTML vs. version in incoming payload):
+   ```javascript
+   window.webxdc.sendUpdate({
+     payload: {type: 'version_mismatch', appVersion: 1.2, serverVersion: 1.3, senderAddr: window.webxdc.selfAddr},
+     summary: 'Update requested'
+   }, 'Version mismatch')
+   ```
+
+2. Server detects mismatch in `onWebXDCUpdate`:
+   - Unregister old msgId.
+   - Build fresh `.xdc` from disk.
+   - Send to chat → gets new msgId.
+   - Re-register new msgId.
+
+3. User swipes back to chat, taps the new card, updates flow to the new msgId.
+
+**Marp detection rules (`marp-detect.ts`):**
+
+Content is marked as slides if either:
+1. **Frontmatter:** File starts with `---\n`, has `marp: true` (or `marp: yes`) in YAML block, then `---\n` again.
+2. **No-frontmatter syntax:** File starts with `---\n`, contains 2+ `---\n`-delimited sections, and no frontmatter YAML.
+
+**Permission verification (`webxdc-filter.ts`):**
+
+Updates are filtered in `filterUpdatesByOwner()` based on:
+- **No owner (legacy unpaired chat):** All updates pass through unfiltered.
+- **1:1 chat (contact count ≤ 2):** Any update with a `senderAddr` passes (only the owner can send updates in 1:1).
+- **Group chat:** Verify `senderAddr` via `lookupContactByAddr(senderAddr)` (strict match) OR TOFU-cached addr.
+  - On strict match: add addr to TOFU cache.
+  - On cache hit: allow update.
+  - On no match: log rejection and drop update.
+- **Missing `senderAddr` in owned chat:** Update is silently dropped.
+
+### Primary source files
+
+| File | Purpose |
+|------|---------|
+| `plugin/webxdc-app.ts` | Base interface for all WebXDC apps (tools, handlers, lifecycle) |
+| `plugin/apps/permissions-app.ts` | Permission prompt card logic; manages request/response flow for tool calls |
+| `plugin/webxdc/permission-prompt.html` | Permission card UI; displays tool details, Allow/Deny buttons; includes `APP_VERSION` |
+| `plugin/apps/file-reviewer-app.ts` | File viewer app; dispatches `dc_send_file` and `dc_send_slides` tools; handles comments + inline editing |
+| `plugin/webxdc/file-reviewer.html` | File/markdown renderer with inline comments, tab bar, Marp slide detection |
+| `plugin/webxdc/file-reviewer.template.html` | Alternative template used in build process |
+| `plugin/file-reviewer.ts` | Session tracker for file-reviewer (msgId per chat, lastUpdate cache) |
+| `plugin/marp-detect.ts` | Detects Marp slide format |
+| `plugin/apps/agent-setup-app.ts` | Agent picker/creator card; all screens (home, create, edit, delete, paired_list, etc.) |
+| `plugin/webxdc/agent-setup.html` | Agent setup UI (glyph icons, model picker, tool selector, trusted-agent toggle) |
+| `plugin/familiar-runtime.ts` | Sandbox, registry, persistence for Familiar apps |
+| `plugin/apps/familiar-app.ts` | WebXDC app wrapper for Familiar runtime |
+| `plugin/xdc-builder.ts` | Shared `.xdc` ZIP builder; prebuilt cache lookup; APP_VERSION extraction |
+| `plugin/permissions.ts` | Permissions `.xdc` builder (thin wrapper around xdc-builder) |
+| `plugin/webxdc-filter.ts` | Owner verification for WebXDC updates (senderAddr validation) |
+| `plugin/server.ts` | Central event loop; WebXDC update polling and per-msgId dispatch |
+
+### Audit notes
+
+**Owner-verification holes:**
+
+1. **Owned chat without `senderAddr` in payload:** Filter silently drops update (correct). Familiar HTML generated by `dc_familiar_create` must validate `senderAddr` presence before send; test in `familiar-runtime.test.ts` `validateHtmlSenderAddr` catches missing refs at creation time. Known limitation: false positive if `senderAddr` appears in a comment or after a `)` in a string literal.
+
+2. **1:1 chat contact-count edge case:** Filter assumes contact count ≤ 2 → 1:1. But contact count includes the bot self; a freshly-created 1:1 might have count = 1 (self only, user not yet fetched). Filter would fall through to strict lookup, which may fail if dc-core returns anonymized selfAddr hashes (see issue #47). **Risk:** Updates from owner in a just-created 1:1 chat might be incorrectly rejected on strict check, then accepted on TOFU.
+
+3. **TOFU cache without expiry:** Once a `senderAddr` is cached in a group chat, it's trusted forever — no expiry or re-verification. **Risk:** If a group member is removed but their addr is cached, and they rejoin, they could impersonate themselves via the cached addr. Mitigation: `clearTrustedSenderAddrs(chatId)` is called on chat unpair; not called on member removal (would require event).
+
+**`senderAddr`-missing updates:**
+
+4. **File-reviewer `close_tab`:** Does not include `senderAddr`. Accepted as-is because it has no side effects (just clears in-memory lastUpdate). **But:** If an attacker spoofs a `close_tab`, they can cause a legitimate file to be forgotten before version-mismatch upgrade (user would lose the document). Mitigation: Validate `senderAddr` in `close_tab` handler. Currently not done.
+
+5. **Familiar handler output:** When handler calls `ctx.sendUpdate(payload)`, the handler author is responsible for including `senderAddr: window.webxdc.selfAddr` in the HTML. Validation via `validateHtmlSenderAddr()` at creation time, but false positives possible.
+
+**Auto-upgrade loops:**
+
+6. **Race on version_mismatch build:** Two instances of the handler both see `version_mismatch`, both call the upgrade path. Both unregister old msgId and rebuild. Second rebuild might re-send before first's new msgId is registered, causing the second update to arrive at an unregistered msgId. Guard: file-reviewer-app has `if (fileReviewer.getViewer(ownerChatId) !== msgId) return`. Permissions app lacks this check.
+
+7. **`APP_VERSION` not monotonic:** If server reads HTML twice and gets different `APP_VERSION` (e.g., during deployment, file changes on disk mid-request), the version field in manifest may not match the version extracted from HTML. Unlikely in practice. **Mitigation:** Single read + cache.
+
+**Session-map leaks:**
+
+8. **Permissions sessions not cleared on chat unpair:** `permissionsSessions` map lives module-scoped; no cleanup on `cleanup.ts` event. Low-risk but non-zero. Mitigation: call `permissionsSessions.delete(chatId)` on unpair.
+
+9. **File-reviewer `activeViewers` not cleared on chat unpair:** Same issue. Mitigated by `if (ownerChatId === null) return` check, so orphaned msgIds are silently ignored.
+
+10. **Familiar instances cleaned on chat cleanup:** `cleanupFamiliarForChat(chatId)` is called in server.ts, which removes instances from maps + deletes persisted files. Correct.
+
+**Familiar sandbox escape surface:**
+
+11. **Function constructor via prototype chain:** Handler can call `({}).constructor.constructor('return globalThis')()` to break out of shadowed globals. Defence-in-depth; primary gate is user review. **Not a bug:** Documented in familiar-runtime.ts module comment.
+
+12. **`import()` keyword not shadowed:** Handler cannot use `import()` (dynamic import) because it's a keyword and can't be a parameter name. Code checks for regex `/\bimport\s*\(/`. Correct.
+
+13. **`setTimeout`/`setInterval` shadowed:** Handler cannot schedule delayed code. Correct.
+
+**Payload size limits:**
+
+14. File-reviewer and familiar both enforce 120 KB max payload size (`120_000` bytes). Files larger than this are split into chunks via binary search on line counts. Each chunk is sent as a separate update (separate tab). Metadata overhead (~500 bytes) is reserved. Chunks are recombined by the viewer.
+
+**Replay-safety bugs in `setUpdateListener(fn, 0)`:**
+
+15. Permission-prompt.html registers with `setUpdateListener(fn, 0)`, triggering synchronous replay of every update that has ever arrived for this msgId. In practice, each chat has a SINGLE permissions msgId (reused), so stale-replay is rare. Leak vector: if the same chat somehow sends a new msgId, replay could show stale requests. **Mitigation:** `sendPermissionRequest()` reuses the existing msgId via `permissionsSessions` map.
+
+---
+
+**Key invariants:**
+- Every `sendUpdate` payload in owned chats MUST include `senderAddr`.
+- Every WebXDC app msgId must be registered in `webxdcAppRegistry` before updates are dispatched.
+- File-reviewer viewer msgId per chat must be consistent (not double-sent).
+- Familiar persistent instances must be valid JSON with required fields (`appId`, `chatId`, `msgId`, `handler`, `html`).
+- No in-app state should depend on msgId < app's last registered msgId (prevents replay-after-reregister bugs).


### PR DESCRIPTION
## Summary

Phase 1 of #64: walks the code area-by-area and writes down what the system actually does. Each feature area gets a short spec covering intended behaviour, state transitions, persisted state, observable surface, and primary source files. Phase 2 (audit) landed as `docs/spec/AUDIT.md` with findings prioritised H/M/L/A.

## What's in the tree

- `docs/spec/README.md` — index + conventions + how to keep the spec accurate.
- `docs/spec/pairing.md` — \`/deltachat:setup\`, armed-window, securejoin, auto-pair, tutorial, allowlist.
- `docs/spec/subagent-lifecycle.md` — LRU cache, idle timeout, stream-json I/O, Unix-socket protocol, reaction mapping.
- `docs/spec/agents-and-bindings.md` — agent YAML registry, bindings, templates + archetypes, badge rendering, YAML import/export.
- `docs/spec/resume.md` — DC ↔ terminal session resume, workingDir write-once, session-agents reverse index.
- `docs/spec/webxdc-apps.md` — all four WebXDC apps + Familiar runtime, auto-upgrade handshake, owner verification.
- `docs/spec/scheduling.md` — cron scheduler, per-job atomic JSON, missed-fire policy.
- `docs/spec/stt.md` — voice transcription via \`@napi-rs/whisper\` + Symphonia.
- `docs/spec/tool-allowlisting.md` — \`allowedBuiltinTools\` / \`allowedMcpServers\`, legacy-field migration.
- `docs/spec/skip-permissions-audit.md` — \`x-dc-skipPermissions\` auto-approve + per-chat markdown audit.
- `docs/spec/AUDIT.md` — consolidated audit findings (~50 items) with severity + type classification.

## Audit headline counts

- **High** (user-visible / correctness): 6 items — e.g. \`close_tab\` missing \`senderAddr\` validation, TOFU cache with no expiry, skip-permissions flag leaking on export, stale socket-level auth after binding mutation.
- **Medium** (reliability / observability): ~15 items — e.g. teleport-out race, auto-upgrade double-fire in permissions-app, rate-limit hit returning boolean instead of structured error.
- **Low** (edge case / cosmetic): ~20 items — orphans, doc-only fixes, narrow race windows.
- **Accept** (documented design constraint): ~12 items — single-writer invariant, same-machine only, Familiar sandbox escape, shared auto-memory, etc.

## .gitignore change

\`docs/\` was globally ignored; this PR keeps that default but re-includes \`docs/spec/\` specifically so the spec is committable while the rest of \`docs/\` stays local (design docs, superpowers plans, etc.).

## Test plan

- [ ] Read through each spec file and confirm it matches current behaviour on this branch.
- [ ] Review `AUDIT.md` severity classifications — anything promoted from L → M or M → H?
- [ ] Decide which H items become follow-up issues now vs. checkboxes on #64.

Closes Phase 1 of #64. Phase 2 (audit) is captured in \`AUDIT.md\`; Phase 3 (maintenance loop + #63 tie-in) is deferred.