### PR TITLE
docs: CONTEXT.md glossary + ADR scaffold with 4 backfilled decisions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,7 @@ docs/upstream-issues/**
 !docs/ARCHITECTURE.md
 !docs/CONTRIBUTING.md
 !docs/d4c-concept-mapping.md
+!docs/adr/
+!docs/adr/**
 /scripts/
 *.log

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,115 @@
+# dc-claude-channel domain glossary
+
+The vocabulary of this codebase. Use these terms exactly when discussing the system, naming variables, or proposing changes. Drift erodes the value — if a new concept emerges that isn't here, add it.
+
+This file is **living**: extend it whenever a session sharpens a fuzzy term, names a new module, or surfaces a load-bearing distinction. The bar for inclusion is "a term that, if not in the glossary, would force a paragraph of explanation each time it's used."
+
+For longer-form architecture documentation, see [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md). For decisions, see [`docs/adr/`](docs/adr/).
+
+---
+
+## Process and dispatch
+
+**Dispatcher** — The single `bun server.ts` process. Owns the DC RPC connection, the MCP server (tools-proxy over a Unix socket), and the subagent LRU cache. One per Delta Chat account.
+
+**Subagent** — A persistent `claude -p` child process bound to one chat. Receives DC messages as user turns over its stdin (stream-json) and emits assistant turns. Cached LRU (default 8 active, 15 min idle).
+
+**Turn** — One user message → assistant loop of N tool calls → final assistant text. A long task is typically one turn with many tool calls inside, not many turns.
+
+**Cold spawn** — Starting a subagent process from scratch with `--resume <sessionId>` to rehydrate prior turn history. Costs ~10s of latency.
+
+**Tools proxy** — The MCP server the dispatcher exposes to subagents over a Unix socket. Every `dc_*` tool call from a subagent goes through this proxy.
+
+---
+
+## Identity and trust
+
+**Agent definition** — Reusable role description authored as YAML at `~/.claude/channels/deltachat/agents/<id>.yaml`. Holds name, model, system prompt, allowed tools, etc. One agent definition can be bound to many chats over time.
+
+**Binding** — Per-chat record at `bindings/<chatId>.json` linking the chat to an agent definition + claude session UUID for `--resume`. Bindings are not reusable across chats; agent definitions are.
+
+**Principal** — Per-contact identity record at `principals/humans/<contactId>.json`. The source of truth for "is this contact trusted to interact with the bot." A principal record exists once a contact has paired; it persists across chats.
+
+**Trust filter** — The dispatcher's gate between DC's full-fidelity local DB and the subagent's context window. Tags every inbound line as `[permissioned]` or `[UNPERMISSIONED]`; lives in `plugin/dispatcher/trust-filter.ts`.
+
+**Permissioned content** — A message whose sender has a principal record. Subagents see permissioned content directly; unpermissioned content is redacted unless the subagent explicitly opts in.
+
+**Capability** — Token-based authorization for cross-contact tool calls (#71, v1.3). A capability says "this contact may invoke this tool." Replaces and refines the older "is the chat owner" check.
+
+**Pairing** — The QR / verification ceremony that creates a principal record. Two paths today: securejoin (DC's native verification) and the agent-setup wall (in-app code exchange).
+
+**Auto-pair** — When a contact who already has a principal record sends in a *new* chat with the bot, the dispatcher silently approves the chat without re-running the ceremony. The trust boundary is contact identity, not chatId.
+
+**Skip-permissions mode** — Per-binding flag that bypasses the permissions WebXDC card for tool calls. Sometimes called "trusted mode."
+
+---
+
+## Agent creation
+
+**Wall** — The first-message-in-a-new-chat exchange that pairs a contact and lets them pick / build an agent. Implemented in the agent-setup WebXDC.
+
+**Coach** — The interview phase of agent creation. The coach asks the user about their needs and proposes a concrete agent definition.
+
+**Leaf** — Atomic unit in the agent-creation catalog at `plugin/leaves/<id>.yaml`. Each leaf describes a specialty (e.g., `personal-attorney`, `family-meal-planner-cook`) with a name, pitch, expertise, liability flag, suggested tools, and combinesWith pointers.
+
+**Path** — Top-level category a leaf belongs to: `Expert`, `Service`, or `Goal`. Drives layout in the catalog and defaults in the coach.
+
+**combinesWith** — Authored one-way pointer from a leaf to other leaves it pairs naturally with. The catalog loader computes the symmetric closure at runtime so two-way navigation works.
+
+**suggestedTools** — Per-leaf list of MCP servers / tool identifiers the leaf wants enabled when it's part of an agent. Schema field exists today; population is incomplete (see #74).
+
+---
+
+## WebXDC apps
+
+**WebXDC app** — A self-contained `.xdc` HTML file the dispatcher sends into a chat. Has a sandboxed runtime; communicates with the dispatcher via `sendUpdate` payloads.
+
+**Familiar** — A WebXDC app with server-side state and a sandboxed handler JS string. Distinguished from a static WebXDC by `requestLLM`, persistent `ctx.state`, and `ctx.sendUpdate`.
+
+**Auto-upgrade protocol** — The contract every WebXDC app implements: detect a version mismatch on receipt and reload. Required so users on stale clients pick up new app versions without manual reinstall.
+
+**App version** — A monotonic version number embedded in each WebXDC's HTML. Bumped on every change; the auto-upgrade protocol triggers on mismatch.
+
+**Permission card** — The WebXDC app shown when a non-trusted subagent requests a tool that requires user approval. One per pending permission request.
+
+**Agent-setup card** — The WebXDC app for agent management: create, switch, edit, delete, resume terminal sessions, teleport to terminal.
+
+**File reviewer** — The WebXDC app for displaying long-form markdown / code with inline commenting.
+
+---
+
+## State and storage
+
+**Channel state dir** — `~/.claude/channels/deltachat/`. Contains `agents/`, `bindings/`, `principals/`, `approved/`, `events/`, `schedules/`, `dc-data/`, etc.
+
+**Approved chats** — Legacy per-chat allowlist at `approved/<chatId>`. Still consulted as a fallback gate during the v1.2 → v1.3 transition; v1.3 derives the allowlist from principals + chat membership instead.
+
+**Event logs** — Four append-only NDJSON streams under `events/`: `tools-*.log`, `turns-*.log`, `permissions-*.log`, `webxdc-*.log`. Surfaced via the `dc_show_events` tool.
+
+**Schedules** — Persistent cron-style jobs at `schedules/<jobId>.json`. Created via `dc_schedule*`; runs deliver synthetic user turns to the target chat's subagent.
+
+**Auto-memory** — Filesystem-based memory at `~/.claude/projects/<cwd-hash>/memory/` with a `MEMORY.md` index and per-fact files. Shared across the dispatcher and all subagents because they share the working directory. Per-agent isolation is being added (#81).
+
+---
+
+## Architecture vocabulary (Ousterhout)
+
+These are the architectural terms used in design discussions, ADR rationale, and the `improve-architecture` skill. Originating in *A Philosophy of Software Design*; not specific to this codebase, but use them consistently.
+
+**Module** — Anything with an interface and an implementation. Function, class, package, file, slice.
+
+**Interface** — Everything a caller must know to use the module: types, invariants, error modes, ordering constraints, config. Not just the type signature.
+
+**Implementation** — The code inside.
+
+**Depth** — Leverage at the interface. *Deep* = a lot of behavior behind a small interface. *Shallow* = interface nearly as complex as the implementation.
+
+**Seam** — Where an interface lives. A place behavior can be altered without editing in place. (Use this, not "boundary.")
+
+**Adapter** — A concrete thing satisfying an interface at a seam.
+
+**Leverage** — What callers get from depth.
+
+**Locality** — What maintainers get from depth: change, bugs, knowledge concentrated in one place.
+
+**Deletion test** — Imagine deleting the module. If complexity vanishes, it was a pass-through. If complexity reappears across N callers, it was earning its keep.

--- a/docs/adr/0001-subagent-per-chat-with-lru-cache.md
+++ b/docs/adr/0001-subagent-per-chat-with-lru-cache.md
@@ -1,0 +1,43 @@
+# ADR-0001: Subagent-per-chat with LRU cache
+
+**Status:** Accepted
+**Date:** 2026-04-15 (backfilled 2026-05-01)
+
+## Context
+
+Every paired chat needs to handle inbound messages by talking to Claude. Three plausible architectures:
+
+1. **Single multiplexed session.** One `claude` process handles all chats, identifying which chat a message belongs to by tagging.
+2. **Per-message cold spawn.** Spawn `claude -p`, deliver one message, exit.
+3. **Per-chat persistent subagent with LRU cache.** Spawn `claude -p` once per chat, keep alive across turns, evict idle ones.
+
+Constraints shaping the choice:
+
+- `claude -p` cold-spawn is ~10s of latency on every message — too slow for conversational UX.
+- Conversation history is rehydrated via `--resume <sessionId>`, but only if the prior session is reachable (sessionId stored in the binding).
+- Each subagent needs its own conversation state (in-flight tool calls, scratch context); multiplexing one process across chats would require external state-management we'd otherwise get for free.
+- Memory pressure: a long-tail of dormant chats shouldn't keep N processes alive forever.
+
+## Decision
+
+Per-chat persistent subagent processes, kept warm in an LRU cache (default 8 active, 15 min idle timeout). Cold spawns only on cache miss. Session UUID persisted on the binding so `--resume` rehydrates prior turns when a chat re-enters the cache.
+
+## Consequences
+
+**Benefits.**
+
+- Warm-path turns are conversational latency (~1s to first token), not cold-spawn latency.
+- Each subagent owns its own state — no per-message correlation logic in the dispatcher.
+- LRU eviction caps process count and memory; idle eviction releases dormant chats automatically.
+- `--resume` recovers history naturally on cache miss; no custom transcript replay.
+
+**Costs.**
+
+- Cache size + idle timeout become tuning parameters. Bad values cause either memory bloat or excessive cold spawns.
+- Process kills (OOM, crash, manual restart) lose in-flight turn state; recovery relies on `--resume` rehydrating from the prior committed turn.
+- Each subagent holds an open MCP socket to the dispatcher; stale connections must be cleaned up on eviction.
+
+**Rejected alternatives.**
+
+- *Single multiplexed session.* Rejected: requires building per-chat state isolation we'd inherit for free from process boundaries; one stuck tool call would block all chats.
+- *Per-message cold spawn.* Rejected: ~10s latency per message is conversationally unusable.

--- a/docs/adr/0002-agent-definition-and-binding-split.md
+++ b/docs/adr/0002-agent-definition-and-binding-split.md
@@ -1,0 +1,47 @@
+# ADR-0002: Agent definition / binding split
+
+**Status:** Accepted
+**Date:** 2026-04-15 (backfilled 2026-05-01)
+
+## Context
+
+Each chat needs to know which agent it's running and which Claude session UUID to resume. Two natural ways to model this:
+
+1. **Unified record.** One file per chat holding agent role + session UUID + per-chat overrides.
+2. **Split: agent definition + binding.** Agent definition is a reusable role; binding is a per-chat pointer to the agent plus the session UUID.
+
+The pull toward unification: simpler mental model, one place to look. The pull toward split: agents are inherently reusable across chats (a "personal attorney" agent serves many chat threads), and editing the role to fix a bug or add a tool should propagate to every chat that uses it.
+
+## Decision
+
+Split into two records:
+
+- **Agent definition** at `~/.claude/channels/deltachat/agents/<id>.yaml` — name, model, system prompt, allowed tools. Reusable across chats.
+- **Binding** at `bindings/<chatId>.json` — `{ agentId, sessionId, inheritClaudeMd, createdAt }`. One per chat.
+
+Editing an agent definition mutates in place; the next turn in every bound chat picks up the change. Bindings are not portable across chats.
+
+## Consequences
+
+**Benefits.**
+
+- A single edit to an agent role propagates to every chat that uses it. No N-chat migration.
+- Sharing/exporting an agent is trivial — copy the YAML.
+- Per-chat state (session UUID, claude.md inheritance flag, future per-chat overrides) lives in the binding without polluting the agent record.
+- Agents-as-templates: import a community-authored agent without inheriting someone else's session state.
+
+**Costs.**
+
+- Two records to keep consistent. A binding's `agentId` can become dangling if the agent definition is deleted; cleanup logic has to handle that.
+- Per-chat overrides (e.g., a model override for one specific chat) require a third concept (binding-level override field) rather than just editing "the chat's record."
+- Two files to load per turn instead of one. Negligible at current scale; worth flagging.
+
+**Rejected alternatives.**
+
+- *Unified record per chat.* Rejected: would force N-way duplication of agent role text and force re-authoring the role to update behavior across chats. Every "fix the system prompt" task would become a migration.
+- *Agent record contains a list of bound chatIds.* Rejected: makes the agent record mutate on every new chat creation, complicating optimistic locking and making "is this agent in use" queries non-local.
+
+## Related
+
+- Agent rebinding (#54) extends this model with the ability to change `agentId` on an existing binding.
+- Per-agent memory (#81) builds on top: agent-level memory dirs are keyed by `agentId`, so memory survives across chats that bind the same agent.

--- a/docs/adr/0003-principals-as-trust-source.md
+++ b/docs/adr/0003-principals-as-trust-source.md
@@ -1,0 +1,46 @@
+# ADR-0003: Principals (contact identity) as the trust source
+
+**Status:** Accepted
+**Date:** 2026-04-25 (backfilled 2026-05-01, ref. v1.2.2 / #66 Option A)
+
+## Context
+
+Pre-v1.2.2, the answer to "is this contact trusted to interact with the bot" was the chat-allowlist (`approved/<chatId>`) and the per-chat owner record. This worked when each contact had exactly one chat with the bot, but broke down for the realistic case:
+
+- A contact already paired in chat X opens a new chat Y with the bot. The chat-allowlist gate sees Y as unapproved and forces another QR/code ceremony. From the contact's perspective, they already proved who they are.
+- Multi-user groups: deciding who's allowed to drive the bot in a group chat is per-contact, not per-chat.
+- Per-contact unpair (revoke this person's trust regardless of which chats they're in) has no clean home in a chat-keyed model.
+
+The trust boundary should be **contact identity**, not **chatId**.
+
+## Decision
+
+Per-contact identity records — **principals** — at `~/.claude/channels/deltachat/principals/humans/<contactId>.json`. The principal record is the source of truth for "is this contact trusted." Reads consult `isContactPermissioned(contactId)`; the legacy chat-allowlist remains as a fallback for pre-Phase-2 installs and as the per-chat owner record.
+
+Per-contact unpair wipes the principal record (and prevents resurrection by the dispatcher's startup backfill).
+
+## Consequences
+
+**Benefits.**
+
+- **Auto-pair across chats.** A paired contact can land in any new chat with the bot and the dispatcher silently approves — the trust boundary is who they are, not which chat. No re-running the QR ceremony.
+- **Per-contact revocation.** Unpairing wipes the principal record once; all of that contact's chats lose access without per-chat cleanup.
+- **Multi-user readiness.** Group chats can authorize per-sender on the basis of principal records, not chat ownership. Unblocks #37, #70.
+- **Cross-cutting trust queries.** "Does any contact have trust" is a single directory scan; "is this contact paired" is a single file existence check.
+
+**Costs.**
+
+- Two-source-of-truth period during the transition. The chat-allowlist still exists; cleanup happens in v1.3 (Option B / #66) when we derive the allowlist from principals + chat membership and drop `approved/`.
+- Backfill complexity. Legacy installs without principal records need a one-time migration; dispatcher startup runs `backfillFromAllowlist`.
+- Per-contact identity is permanent across the bot's lifetime, which means a misbehaving contact unpaired now could re-pair later (intentional, but worth noting).
+
+**Rejected alternatives.**
+
+- *Chat-keyed allowlist as the only trust source.* Rejected: forces re-pairing on every new chat with the same contact; doesn't extend to multi-user groups; per-contact revocation has no home.
+- *Principals as a derived view of the chat-allowlist.* Rejected: derived data fights the goal — we want principals to *be* the source so per-contact operations are first-class.
+
+## Related
+
+- v1.3 #66 Option B (planned) drops `approved/` entirely and derives the chat allowlist from principals + chat membership.
+- v1.3 #71 builds capabilities on top: "this contact has principal X and capability Y" is the v1.3 authorization shape.
+- #70 (drop third-party messages in groups) is enabled by this — the gate becomes `isContactPermissioned(fromId)` instead of `fromId === owner`.

--- a/docs/adr/0004-kill-and-respawn-for-interrupt.md
+++ b/docs/adr/0004-kill-and-respawn-for-interrupt.md
@@ -1,0 +1,48 @@
+# ADR-0004: Kill-and-respawn for interrupt
+
+**Status:** Accepted (planned for v1.3, see #21)
+**Date:** 2026-05-01
+
+## Context
+
+Users want a way to interrupt a long-running subagent turn — the chat-mediated equivalent of Ctrl+C in a terminal. Three implementation paths exist:
+
+1. **Stream-json control frame.** The Claude Agent SDK's `interrupt()` method writes `{type: "control_request", request: {subtype: "interrupt"}}` over its bidirectional channel. Clean, no lost work, but in this codebase we drive `claude -p` directly (no SDK dependency); whether the CLI binary honors control frames in `-p` mode is undocumented and unverified ([upstream tracker: anthropics/claude-code#51078](https://github.com/anthropics/claude-code/issues/51078)).
+2. **SIGINT.** Documented but flaky — [anthropics/claude-code#25629](https://github.com/anthropics/claude-code/issues/25629) reports hangs requiring manual recovery.
+3. **SIGTERM kill + `--resume` respawn.** Use the existing eviction path. Next user message cold-spawns under `--resume <sessionId>`, rehydrating prior turn history. The aborted turn appears in the transcript as an interrupted assistant message.
+
+The 2026-04-10 research notes deferred all three on the grounds that any implementation would be "fragile and lossy." On revisiting, that framing is conservative: an interrupt is **inherently lossy by definition** — the user is asking to abandon in-flight work — so lossiness isn't a strike against the approach, only a property of it.
+
+## Decision
+
+Implement `/stop` (and `!!` per #21) as **SIGTERM kill + `--resume` respawn**. Spawn `claude` in its own process group (`detached: true` + signal the negative PID) so SIGTERM cascades to any child processes the subagent had running (e.g., a long Bash command).
+
+Track upstream control-frame work as a future enhancement that would let us interrupt without losing the in-flight turn — but don't block on it.
+
+## Consequences
+
+**Benefits.**
+
+- Ships today; no upstream dependency.
+- Reuses the existing eviction path (`subagent-cache.evict()` with reason `user_abort`). No new code path for the kill itself.
+- `--resume` continuity is genuinely good: the model rehydrates the transcript and "knows" what it was doing.
+- Process-group spawning prevents orphaned grandchildren (long bash commands, network requests).
+
+**Costs.**
+
+- ~10s respawn latency on the next user message. Acceptable for an abort UX.
+- Whatever tool call was mid-flight dies. Side effects (partial file edits, half-completed git commands, unflushed buffers) are visible in the working tree after; the user accepts those by asking to stop.
+- Original `!!` spec asked for "Claude pauses and summarizes its current work." Kill-and-respawn can't do that mid-process; deferring the summary feature to a follow-up that synthesizes a "summarize the last turn before the interrupt" prompt post-respawn.
+
+**Rejected alternatives.**
+
+- *Wait for upstream control frames.* Rejected: blocks an obviously-useful feature on a tracker with no committed timeline. The kill-and-respawn approach has the same user-visible effect (turn stopped, fresh conversation) for the cost of one cold spawn.
+- *SIGINT.* Rejected: documented to hang ([#25629](https://github.com/anthropics/claude-code/issues/25629)). SIGTERM works.
+- *Side-channel "current step" status file.* Rejected: only as fresh as the subagent updates it; stale exactly when a stuck subagent would matter most.
+- *Between-turn injection (queue `!!`, deliver after current turn ends).* Rejected: defeats the use case — if Claude is mid-Bash on a 5-minute test suite, the user has given up by the time the queued message lands.
+
+## Related
+
+- [#21](https://github.com/jhayashi/dc-claude-channel/issues/21) — interrupt feature tracking
+- [Upstream: anthropics/claude-code#51078](https://github.com/anthropics/claude-code/issues/51078) — stream-json cancel/supersede primitive that would unblock a non-lossy interrupt
+- ADR-0001 — the LRU cache and `--resume` mechanic that this decision relies on

--- a/docs/adr/ADR-template.md
+++ b/docs/adr/ADR-template.md
@@ -1,0 +1,20 @@
+# ADR-NNNN: Title
+
+**Status:** Proposed | Accepted | Superseded by ADR-NNNN
+**Date:** YYYY-MM-DD
+
+## Context
+
+What forces are at play. What problem is being decided. What alternatives are on the table.
+
+Keep this tight — a few paragraphs. If there's a longer-form design doc, link to it instead of duplicating.
+
+## Decision
+
+What we're doing. Stated as a positive choice, not a list of tradeoffs.
+
+## Consequences
+
+What follows from the decision. Benefits, costs, and the things future contributors should know.
+
+Include the **rejected alternatives** here, with one-line reasons, so future sessions don't keep re-suggesting them.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,26 @@
+# Architecture Decision Records
+
+Each ADR captures a load-bearing decision: what was decided, why, and what alternatives were rejected. The point is to prevent re-litigating the same question across sessions, code reviews, and onboarding.
+
+**When to write one.**
+
+- A future reviewer would ask "why this and not the obvious alternative?" — and the obvious alternative has a real reason it was rejected.
+- A refactor was suggested and turned down for a load-bearing reason; you don't want the same suggestion to keep coming back.
+- A constraint was discovered (upstream limitation, dc-core behavior, security boundary) that shaped the design and isn't visible from the code alone.
+
+**When NOT to write one.**
+
+- The reason is ephemeral ("not worth it right now," "out of scope for this PR").
+- The reason is self-evident from the code.
+- The decision is implementation detail rather than architecture.
+
+**Format.** ADRs are short. Status, context, decision, consequences. No long preamble. Numbered sequentially in `NNNN-title.md`. Status moves through `Proposed → Accepted → Superseded` (rarely `Rejected`). Don't edit accepted ADRs in place; supersede them with a new one.
+
+See [ADR-template.md](ADR-template.md) for the skeleton.
+
+## Index
+
+- [ADR-0001](0001-subagent-per-chat-with-lru-cache.md) — Subagent-per-chat with LRU cache (vs single multiplexed session)
+- [ADR-0002](0002-agent-definition-and-binding-split.md) — Agent definition / binding split (vs unified record)
+- [ADR-0003](0003-principals-as-trust-source.md) — Principals (contact identity) as the trust source (vs chatId-based ownership)
+- [ADR-0004](0004-kill-and-respawn-for-interrupt.md) — Kill-and-respawn for interrupt (vs blocked on upstream control frames)


### PR DESCRIPTION
## Summary

- Add `CONTEXT.md` at repo root: project domain glossary (dispatcher, subagent, binding, principal, leaf, capability, trust filter, etc.) plus the Ousterhout architectural vocabulary (depth, seams, leverage, locality, deletion test). Living document — updated inline when sessions sharpen or add terms.
- Bootstrap `docs/adr/` with a README, template, and four backfilled ADRs for decisions that already shipped:
  - ADR-0001: Subagent-per-chat with LRU cache
  - ADR-0002: Agent definition / binding split
  - ADR-0003: Principals as trust source
  - ADR-0004: Kill-and-respawn for interrupt
- Extend `.gitignore`'s `docs/**` opt-in pattern to include `docs/adr/`.

## Why

The codebase has accumulated enough idiosyncratic vocabulary (subagent vs agent, binding vs definition, principal vs owner, capability vs allowlist) that conversations and refactors regularly burn paragraphs re-establishing terms. CONTEXT.md gives Claude (and humans) a single source of truth, which compresses conversation tokens-per-session and prevents drift in naming.

ADRs prevent re-litigating decisions that already have load-bearing reasons. Future architecture reviews can read `docs/adr/` and skip re-suggesting things we already evaluated.

This lays the groundwork for a custom `improve-architecture` skill (Matt Pocock-inspired but trimmed and self-contained) that consumes CONTEXT.md vocabulary and respects ADR decisions. The skill itself is a follow-up PR.

## Test plan

- [ ] Read CONTEXT.md end to end; flag any term that's wrong, missing, or fuzzy.
- [ ] Read each ADR; verify the rejected-alternatives section is complete enough that a future session wouldn't re-suggest the rejected thing.
- [ ] Confirm `docs/adr/` files are tracked (gitignore exception works).
- [ ] No code changes, no test changes — `bun test` should still pass identically (919 pass, 7 skip baseline confirmed pre-commit).