### PR TITLE
refactor: consolidate the capability decision (resolve once per message)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -38,7 +38,7 @@ For longer-form architecture documentation, see [`docs/ARCHITECTURE.md`](docs/AR
 
 **Permissioned content** — A message whose sender has a contact record with non-empty capabilities. Subagents see permissioned content directly; unpermissioned content is redacted unless the subagent explicitly opts in.
 
-**Capability** — Token-based authorization for cross-contact tool calls (#71, v1.3). A capability says "this contact may invoke this tool." Replaces and refines the older "is the chat owner" check.
+**Capability** — Token-based authorization for cross-contact tool calls (#71, v1.3). A capability says "this contact may invoke this tool." Replaces and refines the older "is the chat owner" check. The sender's capability set is resolved once per message (cached in the dispatcher's per-message driver context) and decided purely via `decideCapability(caps, required)`; a declared `requestor_contact_id` re-resolves fresh.
 
 **Pairing** — The QR / verification ceremony that creates a contact record. Two paths today: securejoin (DC's native verification) and the agent-setup wall (in-app code exchange).
 

--- a/plugin/access/capabilities.ts
+++ b/plugin/access/capabilities.ts
@@ -26,7 +26,6 @@
  */
 
 import { hasCapability } from "./capability-bundles.js";
-import { getCapabilitiesFor } from "./contact-policy.js";
 
 /** Tool annotations without `requiresCapability` default to chat-tier. */
 const DEFAULT_REQUIRED_CAPABILITY = "chat";
@@ -44,34 +43,6 @@ export interface CapabilityDecision {
    * `would_deny` — bundle lacks the requirement; slice 4 will refuse the call.
    */
   decision: "allow" | "would_deny";
-}
-
-/**
- * Evaluate whether `originatorContactId` (null for terminal sessions)
- * has the capability required by a tool. Returns the decision plus
- * the data the audit log needs.
- */
-export function evaluateCapability(
-  agentId: string,
-  originatorContactId: number | null,
-  requiredCapability: string | null | undefined,
-): CapabilityDecision {
-  const required = requiredCapability && requiredCapability.length > 0
-    ? requiredCapability
-    : DEFAULT_REQUIRED_CAPABILITY;
-
-  // Terminal calls bypass — the terminal session is the subscriber.
-  if (originatorContactId === null) {
-    return {
-      required,
-      originatorCapabilities: TERMINAL_BUNDLE,
-      decision: "allow",
-    };
-  }
-
-  const originatorCapabilities = getCapabilitiesFor(agentId, originatorContactId);
-  const decision = hasCapability(originatorCapabilities, required) ? "allow" : "would_deny";
-  return { required, originatorCapabilities, decision };
 }
 
 /**

--- a/plugin/access/capabilities.ts
+++ b/plugin/access/capabilities.ts
@@ -73,3 +73,23 @@ export function evaluateCapability(
   const decision = hasCapability(originatorCapabilities, required) ? "allow" : "would_deny";
   return { required, originatorCapabilities, decision };
 }
+
+/**
+ * Pure capability decision: given an already-resolved capability set
+ * (or `null` for a terminal session, which is the subscriber by
+ * definition), decide whether it covers the requirement. No filesystem
+ * access — the caller resolves caps (once per message, cache-aware).
+ */
+export function decideCapability(
+  caps: readonly string[] | null,
+  requiredCapability: string | null | undefined,
+): CapabilityDecision {
+  const required = requiredCapability && requiredCapability.length > 0
+    ? requiredCapability
+    : DEFAULT_REQUIRED_CAPABILITY;
+  if (caps === null) {
+    return { required, originatorCapabilities: TERMINAL_BUNDLE, decision: "allow" };
+  }
+  const decision = hasCapability(caps, required) ? "allow" : "would_deny";
+  return { required, originatorCapabilities: caps, decision };
+}

--- a/plugin/access/contact-policy.ts
+++ b/plugin/access/contact-policy.ts
@@ -149,9 +149,11 @@ export function isContactTrustedForContent(agentId: string, contactId: number): 
  *   4. Neither → `["*"]` (legacy backfill safety; pre-v1.3 records
  *      written without role/capabilities are treated as `subscriber`).
  *
- * Intentionally NOT memoized — role changes via `setHumanRole`
- * (slice 6/7) must take effect on the next tool call. The lookup is
- * one stat + one small JSON read; cheap.
+ * Not memoized inside this function. The dispatcher resolves the message
+ * sender's caps once per message (cached in `_currentDriver`) and re-resolves
+ * fresh for a declared `requestor_contact_id`, so a role change via
+ * `setContactRole` takes effect on the sender's next message. The lookup is
+ * one stat + one small JSON read.
  */
 export function getCapabilitiesFor(agentId: string, contactId: number): string[] {
   const p = loadContact(agentId, contactId);

--- a/plugin/access/gate.ts
+++ b/plugin/access/gate.ts
@@ -30,6 +30,7 @@
  */
 
 import type { CapabilityDecision } from "./capabilities.js";
+import { decideCapability } from "./capabilities.js";
 
 export interface GateDeps {
   agentId: string;
@@ -44,7 +45,14 @@ export interface GateDeps {
    * the subagent self-declared the requestor.
    */
   defaultOriginator: (chatId: number) => number | null;
-  evaluateCapability: (agentId: string, originator: number | null, required: string | null | undefined) => CapabilityDecision;
+  /**
+   * Resolves the originator's capability set, or `null` for a terminal /
+   * unowned originator (decideCapability treats null as the subscriber).
+   * The production impl is cache-aware: it returns the per-message cached
+   * caps when `originator` is the message sender, else loads fresh. May
+   * throw on a corrupt Contact record (routed to capability_lookup_error).
+   */
+  capsFor: (chatId: number, originator: number | null) => readonly string[] | null;
   getChatContacts: (chatId: number) => Promise<number[]>;
   logf?: (fmt: string, ...args: unknown[]) => void;
 }
@@ -209,11 +217,13 @@ export async function applyCapabilityGate(
   // the slice-3-5 review fix). Catch and route to lookup-error so the
   // operator's `jq` queries can distinguish "we said no" from "we
   // couldn't decide" (security review T4).
-  let decision: CapabilityDecision;
+  // Resolve caps (may throw on a corrupt Contact record — security review
+  // T4: distinguish "we said no" from "we couldn't decide"); decide purely.
+  let caps: readonly string[] | null;
   try {
-    decision = deps.evaluateCapability(deps.agentId, originator, required);
+    caps = deps.capsFor(chatId, originator);
   } catch (err) {
-    deps.logf?.("capability gate: evaluateCapability threw for chat=%d tool=%s: %v", chatId, toolName, err);
+    deps.logf?.("capability gate: capsFor threw for chat=%d tool=%s: %v", chatId, toolName, err);
     return {
       outcome: {
         kind: "deny",
@@ -226,6 +236,7 @@ export async function applyCapabilityGate(
       scrubbedArgs,
     };
   }
+  const decision: CapabilityDecision = decideCapability(caps, required);
 
   if (decision.decision === "would_deny") {
     return {

--- a/plugin/access/gate.ts
+++ b/plugin/access/gate.ts
@@ -13,13 +13,11 @@
  *   2. Validate `requestor_contact_id` if present: positive integer +
  *      chat membership. Reject malformed/non-member values with
  *      `capability_invalid_requestor`.
- *   3. Run `evaluateCapability(originator, requiredCapability)` —
- *      wrapped in try/catch per security review T4. Principal-store
- *      errors (corrupt records, FS errors that aren't ENOENT) deny
- *      with `capability_lookup_error`. Coverage gap from slice 4
- *      (Oliver P2 #1) is fixed by the loadContact change in this same
- *      review batch.
- *   4. If `evaluateCapability` returns `would_deny`, deny with
+ *   3. Resolve the originator's caps via `capsFor` (cache-aware; wrapped
+ *      in try/catch per security review T4 — corrupt records / non-ENOENT
+ *      FS errors deny with `capability_lookup_error`), then decide purely
+ *      with `decideCapability(caps, requiredCapability)`.
+ *   4. If `decideCapability` returns `would_deny`, deny with
  *      `capability_deny`.
  *   5. Otherwise, allow. server.ts then dispatches the tool.
  *
@@ -211,14 +209,12 @@ export async function applyCapabilityGate(
     originator = n;
   }
 
-  // Run the capability check. `evaluateCapability` may throw if the
-  // principal store has a corrupt record (loadContact propagates non-
-  // ENOENT FS errors and JSON-parse / schema-mismatch failures since
-  // the slice-3-5 review fix). Catch and route to lookup-error so the
-  // operator's `jq` queries can distinguish "we said no" from "we
-  // couldn't decide" (security review T4).
-  // Resolve caps (may throw on a corrupt Contact record — security review
-  // T4: distinguish "we said no" from "we couldn't decide"); decide purely.
+  // Run the capability check. capsFor may throw if the Contact store has a
+  // corrupt record (loadContact propagates non-ENOENT FS errors and
+  // JSON-parse / schema-mismatch failures). Catch and route to lookup-error
+  // so the operator's `jq` queries can distinguish "we said no" from "we
+  // couldn't decide" (security review T4). decideCapability is pure and
+  // never throws.
   let caps: readonly string[] | null;
   try {
     caps = deps.capsFor(chatId, originator);

--- a/plugin/access/index.ts
+++ b/plugin/access/index.ts
@@ -10,9 +10,8 @@
  *   chat-allowlist (isContactPermissioned, getCapabilitiesFor, etc.).
  *   Split out in v1.3 to break a chat-allowlist ↔ contacts cycle.
  * - `./capability-bundles.ts` — role → capability set
- * - `./capabilities.ts` — per-tool capability evaluator
- *   (`evaluateCapability` resolves + decides; `decideCapability` is the
- *   pure decision over an already-resolved cap set)
+ * - `./capabilities.ts` — pure capability decision (`decideCapability`)
+ *   over an already-resolved cap set
  * - `./gate.ts` — orchestration helper for the dispatcher's capability gate
  */
 

--- a/plugin/access/index.ts
+++ b/plugin/access/index.ts
@@ -11,6 +11,8 @@
  *   Split out in v1.3 to break a chat-allowlist ↔ contacts cycle.
  * - `./capability-bundles.ts` — role → capability set
  * - `./capabilities.ts` — per-tool capability evaluator
+ *   (`evaluateCapability` resolves + decides; `decideCapability` is the
+ *   pure decision over an already-resolved cap set)
  * - `./gate.ts` — orchestration helper for the dispatcher's capability gate
  */
 

--- a/plugin/server.ts
+++ b/plugin/server.ts
@@ -1446,7 +1446,7 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
  * Subagent runs are serialized per chat by the cache, so a single
  * Map<chatId, contactId> is race-free.
  */
-const _currentDriver = new Map<number, { contactId: number; caps: readonly string[] }>()
+const _currentDriver = new Map<number, { contactId: number; caps?: readonly string[] }>()
 function defaultOriginatorFor(chatId: number): number | null {
   const driver = _currentDriver.get(chatId)
   if (driver !== undefined) return driver.contactId
@@ -2421,10 +2421,17 @@ async function main(): Promise<void> {
     // the capability gate runs against THEIR caps (not the chat owner's)
     // for every tool call the subagent makes during this turn.
     if (msg.fromId && msg.fromId > 0) {
-      _currentDriver.set(chatId, {
-        contactId: msg.fromId,
-        caps: access.getCapabilitiesFor(access.DEFAULT_AGENT_ID, msg.fromId),
-      })
+      // Resolve the sender's caps once for the turn. If the Contact record is
+      // corrupt (getCapabilitiesFor throws), leave caps uncached so the gate
+      // resolves per-tool-call and routes the error to capability_lookup_error
+      // — rather than failing the whole turn here, outside the dispatch try.
+      let caps: readonly string[] | undefined
+      try {
+        caps = access.getCapabilitiesFor(access.DEFAULT_AGENT_ID, msg.fromId)
+      } catch (err) {
+        logf('currentDriver: caps resolve failed chat=%d contact=%d: %v', chatId, msg.fromId, err)
+      }
+      _currentDriver.set(chatId, { contactId: msg.fromId, caps })
     }
     try {
       const result = await subagentCache.dispatch(chatId, formatSubagentInput(enrichedMsg))

--- a/plugin/server.ts
+++ b/plugin/server.ts
@@ -1534,11 +1534,11 @@ mcp.setRequestHandler(CallToolRequestSchema, async (req) => {
     : null
   const start = Date.now()
   const emit = (ok: boolean, errorCode: string | null): void => {
-    // Terminal calls have no contact-id originator — evaluateCapability
+    // Terminal calls have no contact-id originator — decideCapability
     // returns `allow` with the wildcard bundle. The capability fields
     // are still logged for symmetry with subagent calls.
     const requiredCapability = requiredCapabilityFor(req.params.name)
-    const cap = access.evaluateCapability(access.DEFAULT_AGENT_ID, null, requiredCapability)
+    const cap = access.decideCapability(null, requiredCapability)
     logToolCall({
       ts: new Date().toISOString(),
       source: 'terminal',

--- a/plugin/server.ts
+++ b/plugin/server.ts
@@ -787,7 +787,11 @@ const socketServer = new SocketServer({
         {
           agentId: access.DEFAULT_AGENT_ID,
           defaultOriginator: defaultOriginatorFor,
-          evaluateCapability: access.evaluateCapability,
+          capsFor: (cid, originator) => {
+            if (originator === null) return null
+            const cached = currentDriverCaps(cid, originator)
+            return cached !== undefined ? cached : access.getCapabilitiesFor(access.DEFAULT_AGENT_ID, originator)
+          },
           getChatContacts: (id) => client.getChatContacts(id),
           logf,
         },

--- a/plugin/server.ts
+++ b/plugin/server.ts
@@ -1442,11 +1442,16 @@ mcp.setRequestHandler(ListToolsRequestSchema, async () => ({
  * Subagent runs are serialized per chat by the cache, so a single
  * Map<chatId, contactId> is race-free.
  */
-const _currentDriver = new Map<number, number>()
+const _currentDriver = new Map<number, { contactId: number; caps: readonly string[] }>()
 function defaultOriginatorFor(chatId: number): number | null {
   const driver = _currentDriver.get(chatId)
-  if (driver !== undefined) return driver
+  if (driver !== undefined) return driver.contactId
   return access.firstPermissionedContact(chatId)
+}
+/** Caps resolved once for the current message's sender; undefined for synthetic/scheduled turns or a different contact. */
+function currentDriverCaps(chatId: number, contactId: number): readonly string[] | undefined {
+  const driver = _currentDriver.get(chatId)
+  return driver && driver.contactId === contactId ? driver.caps : undefined
 }
 
 /**
@@ -2412,7 +2417,10 @@ async function main(): Promise<void> {
     // the capability gate runs against THEIR caps (not the chat owner's)
     // for every tool call the subagent makes during this turn.
     if (msg.fromId && msg.fromId > 0) {
-      _currentDriver.set(chatId, msg.fromId)
+      _currentDriver.set(chatId, {
+        contactId: msg.fromId,
+        caps: access.getCapabilitiesFor(access.DEFAULT_AGENT_ID, msg.fromId),
+      })
     }
     try {
       const result = await subagentCache.dispatch(chatId, formatSubagentInput(enrichedMsg))

--- a/plugin/test/capabilities.test.ts
+++ b/plugin/test/capabilities.test.ts
@@ -18,7 +18,15 @@ beforeEach(() => {
 
 afterAll(() => rmSync(root, { recursive: true, force: true }));
 
-describe("evaluateCapability — happy path", () => {
+// Resolve + decide, the way the dispatcher composes it for the default
+// originator: getCapabilitiesFor(contactId) → decideCapability(caps, required).
+// A null contactId is a terminal session (no record load; subscriber bundle).
+function decide(contactId: number | null, required: string | null | undefined) {
+  const caps = contactId === null ? null : access.getCapabilitiesFor(access.DEFAULT_AGENT_ID, contactId);
+  return access.decideCapability(caps, required);
+}
+
+describe("capability decision (role → caps → decision) — happy path", () => {
   test("subscriber gets allow on every annotated capability", () => {
     access.writeContact(access.DEFAULT_AGENT_ID, {
       kind: "human",
@@ -28,9 +36,9 @@ describe("evaluateCapability — happy path", () => {
       capabilities: ["*"],
     });
     for (const cap of ["chat", "private_data_read", "private_data_write", "real_world_action", "infrastructure"]) {
-      const decision = access.evaluateCapability(access.DEFAULT_AGENT_ID, 50, cap);
-      expect(decision.decision).toBe("allow");
-      expect(decision.required).toBe(cap);
+      const d = decide(50, cap);
+      expect(d.decision).toBe("allow");
+      expect(d.required).toBe(cap);
     }
   });
 
@@ -42,10 +50,10 @@ describe("evaluateCapability — happy path", () => {
       role: "family-member",
       capabilities: ["chat", "low_stakes_*"],
     });
-    expect(access.evaluateCapability(access.DEFAULT_AGENT_ID, 60, "chat").decision).toBe("allow");
-    expect(access.evaluateCapability(access.DEFAULT_AGENT_ID, 60, "low_stakes_chat").decision).toBe("allow");
-    expect(access.evaluateCapability(access.DEFAULT_AGENT_ID, 60, "private_data_read").decision).toBe("would_deny");
-    expect(access.evaluateCapability(access.DEFAULT_AGENT_ID, 60, "real_world_action").decision).toBe("would_deny");
+    expect(decide(60, "chat").decision).toBe("allow");
+    expect(decide(60, "low_stakes_chat").decision).toBe("allow");
+    expect(decide(60, "private_data_read").decision).toBe("would_deny");
+    expect(decide(60, "real_world_action").decision).toBe("would_deny");
   });
 
   test("guest gets allow on chat, deny on everything else", () => {
@@ -56,22 +64,21 @@ describe("evaluateCapability — happy path", () => {
       role: "guest",
       capabilities: ["chat"],
     });
-    expect(access.evaluateCapability(access.DEFAULT_AGENT_ID, 70, "chat").decision).toBe("allow");
-    expect(access.evaluateCapability(access.DEFAULT_AGENT_ID, 70, "private_data_read").decision).toBe("would_deny");
-    expect(access.evaluateCapability(access.DEFAULT_AGENT_ID, 70, "infrastructure").decision).toBe("would_deny");
+    expect(decide(70, "chat").decision).toBe("allow");
+    expect(decide(70, "private_data_read").decision).toBe("would_deny");
+    expect(decide(70, "infrastructure").decision).toBe("would_deny");
   });
 });
 
-describe("evaluateCapability — fail-closed paths", () => {
+describe("capability decision — fail-closed paths", () => {
   test("unknown contact gets would_deny on every capability", () => {
-    expect(access.evaluateCapability(access.DEFAULT_AGENT_ID, 9999, "chat").decision).toBe("would_deny");
-    expect(access.evaluateCapability(access.DEFAULT_AGENT_ID, 9999, "private_data_read").decision).toBe("would_deny");
-    expect(access.evaluateCapability(access.DEFAULT_AGENT_ID, 9999, "infrastructure").decision).toBe("would_deny");
+    expect(decide(9999, "chat").decision).toBe("would_deny");
+    expect(decide(9999, "private_data_read").decision).toBe("would_deny");
+    expect(decide(9999, "infrastructure").decision).toBe("would_deny");
   });
 
   test("unknown contact reports empty originator capabilities", () => {
-    const decision = access.evaluateCapability(access.DEFAULT_AGENT_ID, 9999, "chat");
-    expect(decision.originatorCapabilities).toEqual([]);
+    expect(decide(9999, "chat").originatorCapabilities).toEqual([]);
   });
 
   test("explicit empty capabilities array denies even subscribers", () => {
@@ -82,11 +89,11 @@ describe("evaluateCapability — fail-closed paths", () => {
       role: "subscriber",
       capabilities: [],
     });
-    expect(access.evaluateCapability(access.DEFAULT_AGENT_ID, 80, "chat").decision).toBe("would_deny");
+    expect(decide(80, "chat").decision).toBe("would_deny");
   });
 });
 
-describe("evaluateCapability — null/missing required capability", () => {
+describe("capability decision — null/missing required capability", () => {
   test("null required capability is treated as `chat` tier (safe default)", () => {
     access.writeContact(access.DEFAULT_AGENT_ID, {
       kind: "human",
@@ -96,9 +103,9 @@ describe("evaluateCapability — null/missing required capability", () => {
       capabilities: ["chat"],
     });
     // Tool authors who haven't annotated yet get chat-tier behavior.
-    const decision = access.evaluateCapability(access.DEFAULT_AGENT_ID, 90, null);
-    expect(decision.decision).toBe("allow");
-    expect(decision.required).toBe("chat");
+    const d = decide(90, null);
+    expect(d.decision).toBe("allow");
+    expect(d.required).toBe("chat");
   });
 
   test("undefined required capability is treated as `chat` tier", () => {
@@ -109,29 +116,27 @@ describe("evaluateCapability — null/missing required capability", () => {
       role: "guest",
       capabilities: ["chat"],
     });
-    const decision = access.evaluateCapability(access.DEFAULT_AGENT_ID, 91, undefined);
-    expect(decision.decision).toBe("allow");
-    expect(decision.required).toBe("chat");
+    const d = decide(91, undefined);
+    expect(d.decision).toBe("allow");
+    expect(d.required).toBe("chat");
   });
 });
 
-describe("evaluateCapability — null originator (terminal calls)", () => {
-  test("null originator gets allow with would_deny=false (terminal session)", () => {
-    // Terminal-CC calls have no originator contact id. Slice 3 logs them
-    // as `allow` (the terminal IS the subscriber by definition); slice 4
-    // keeps this behavior — terminal calls are unrestricted.
-    const decision = access.evaluateCapability(access.DEFAULT_AGENT_ID, null, "infrastructure");
-    expect(decision.decision).toBe("allow");
-    expect(decision.required).toBe("infrastructure");
-    expect(decision.originatorCapabilities).toEqual(["*"]);
+describe("capability decision — null originator (terminal calls)", () => {
+  test("null originator gets allow with the wildcard bundle (terminal session)", () => {
+    // Terminal-CC calls have no originator contact id — the terminal IS the
+    // subscriber by definition, so the decision is `allow` with `["*"]`.
+    const d = decide(null, "infrastructure");
+    expect(d.decision).toBe("allow");
+    expect(d.required).toBe("infrastructure");
+    expect(d.originatorCapabilities).toEqual(["*"]);
   });
 });
 
-describe("evaluateCapability — relay case (requestor_contact_id)", () => {
-  // Slice 4 commit 2: the dispatcher resolves originator from
-  // args.requestor_contact_id when present (and validates chat
-  // membership outside the helper). evaluateCapability itself just
-  // takes whichever contactId the caller chose.
+describe("capability decision — relay case (requestor_contact_id)", () => {
+  // The dispatcher resolves the originator from args.requestor_contact_id when
+  // present (validating chat membership in the gate). Whichever contactId the
+  // gate chose is what gets resolved + decided here.
 
   test("subscriber's caps used when no requestor declared (default path)", () => {
     access.writeContact(access.DEFAULT_AGENT_ID, {
@@ -141,7 +146,7 @@ describe("evaluateCapability — relay case (requestor_contact_id)", () => {
       role: "subscriber",
       capabilities: ["*"],
     });
-    expect(access.evaluateCapability(access.DEFAULT_AGENT_ID, 100, "private_data_write").decision).toBe("allow");
+    expect(decide(100, "private_data_write").decision).toBe("allow");
   });
 
   test("family-member's caps used when declared as requestor", () => {
@@ -161,9 +166,9 @@ describe("evaluateCapability — relay case (requestor_contact_id)", () => {
     });
     // Subscriber's chat agent declares requestor = family-member.
     // Gate runs against family-member's bundle.
-    expect(access.evaluateCapability(access.DEFAULT_AGENT_ID, 200, "chat").decision).toBe("allow");
-    expect(access.evaluateCapability(access.DEFAULT_AGENT_ID, 200, "private_data_write").decision).toBe("would_deny");
-    expect(access.evaluateCapability(access.DEFAULT_AGENT_ID, 200, "real_world_action").decision).toBe("would_deny");
+    expect(decide(200, "chat").decision).toBe("allow");
+    expect(decide(200, "private_data_write").decision).toBe("would_deny");
+    expect(decide(200, "real_world_action").decision).toBe("would_deny");
   });
 
   test("untrusted-agent declared as requestor stays in chat-tier", () => {
@@ -174,9 +179,9 @@ describe("evaluateCapability — relay case (requestor_contact_id)", () => {
       role: "untrusted-agent",
       capabilities: ["chat"],
     });
-    expect(access.evaluateCapability(access.DEFAULT_AGENT_ID, 300, "chat").decision).toBe("allow");
-    expect(access.evaluateCapability(access.DEFAULT_AGENT_ID, 300, "private_data_read").decision).toBe("would_deny");
-    expect(access.evaluateCapability(access.DEFAULT_AGENT_ID, 300, "infrastructure").decision).toBe("would_deny");
+    expect(decide(300, "chat").decision).toBe("allow");
+    expect(decide(300, "private_data_read").decision).toBe("would_deny");
+    expect(decide(300, "infrastructure").decision).toBe("would_deny");
   });
 });
 

--- a/plugin/test/capabilities.test.ts
+++ b/plugin/test/capabilities.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import * as access from "../access/index.js";
+import { decideCapability } from "../access/capabilities.js";
 
 const root = mkdtempSync(join(tmpdir(), "dc-capabilities-"));
 const agentsDir = join(root, "agents");
@@ -176,5 +177,26 @@ describe("evaluateCapability — relay case (requestor_contact_id)", () => {
     expect(access.evaluateCapability(access.DEFAULT_AGENT_ID, 300, "chat").decision).toBe("allow");
     expect(access.evaluateCapability(access.DEFAULT_AGENT_ID, 300, "private_data_read").decision).toBe("would_deny");
     expect(access.evaluateCapability(access.DEFAULT_AGENT_ID, 300, "infrastructure").decision).toBe("would_deny");
+  });
+});
+
+describe("decideCapability", () => {
+  test("null caps (terminal session) → allow with wildcard bundle", () => {
+    const d = decideCapability(null, "chat");
+    expect(d.decision).toBe("allow");
+    expect(d.originatorCapabilities).toEqual(["*"]);
+    expect(d.required).toBe("chat");
+  });
+  test("caps cover the requirement → allow", () => {
+    expect(decideCapability(["*"], "low_stakes_email").decision).toBe("allow");
+    expect(decideCapability(["chat"], "chat").decision).toBe("allow");
+  });
+  test("caps lack the requirement → would_deny", () => {
+    expect(decideCapability(["chat"], "low_stakes_email").decision).toBe("would_deny");
+    expect(decideCapability([], "chat").decision).toBe("would_deny");
+  });
+  test("missing/empty required defaults to chat tier", () => {
+    expect(decideCapability(["chat"], undefined).required).toBe("chat");
+    expect(decideCapability(["chat"], "").required).toBe("chat");
   });
 });

--- a/plugin/test/gate.test.ts
+++ b/plugin/test/gate.test.ts
@@ -1,5 +1,4 @@
 import { describe, test, expect } from "bun:test";
-import type { CapabilityDecision } from "../access/capabilities.js";
 import type { GateDeps, GateOutcome } from "../access/gate.js";
 import { applyCapabilityGate, withRequestorParam } from "../access/gate.js";
 
@@ -9,23 +8,11 @@ function makeDeps(overrides: Partial<GateDeps> = {}): GateDeps {
   return {
     agentId: 'claude-code',
     defaultOriginator: () => 50, // default subscriber
-    evaluateCapability: () => ({
-      required: "chat",
-      originatorCapabilities: ["*"],
-      decision: "allow",
-    }),
+    capsFor: () => ["*"],        // wildcard → allow; tests override to drive deny
     getChatContacts: async () => [1, 50],
     logf: () => {},
     ...overrides,
   };
-}
-
-function decision(
-  originatorCapabilities: readonly string[],
-  required: string,
-  d: "allow" | "would_deny",
-): CapabilityDecision {
-  return { required, originatorCapabilities, decision: d };
 }
 
 // ── Happy path ──────────────────────────────────────────────────────────────
@@ -34,10 +21,9 @@ describe("applyCapabilityGate — allow paths", () => {
   test("default originator (pairing contact), capability covered → allow", async () => {
     const result = await applyCapabilityGate(7, "dc_send_file", {}, "private_data_write", makeDeps({
       defaultOriginator: () => 50,
-      evaluateCapability: (_agentId, id, req) => {
+      capsFor: (_chatId, id) => {
         expect(id).toBe(50);
-        expect(req).toBe("private_data_write");
-        return decision(["*"], "private_data_write", "allow");
+        return ["*"];
       },
     }));
     expect(result.outcome.kind).toBe("allow");
@@ -52,9 +38,9 @@ describe("applyCapabilityGate — allow paths", () => {
     const result = await applyCapabilityGate(7, "dc_send", { requestor_contact_id: "200" }, "chat", makeDeps({
       defaultOriginator: () => 50,
       getChatContacts: async () => [1, 50, 200],
-      evaluateCapability: (_agentId, id) => {
+      capsFor: (_chatId, id) => {
         expect(id).toBe(200); // gate uses declared requestor, not pairing contact
-        return decision(["chat", "low_stakes_*"], "chat", "allow");
+        return ["chat", "low_stakes_*"];
       },
     }));
     expect(result.outcome.kind).toBe("allow");
@@ -67,17 +53,14 @@ describe("applyCapabilityGate — allow paths", () => {
   test("requestor_contact_id passed as number (not string) is accepted", async () => {
     const result = await applyCapabilityGate(7, "dc_send", { requestor_contact_id: 200 }, "chat", makeDeps({
       getChatContacts: async () => [1, 50, 200],
-      evaluateCapability: () => decision(["chat"], "chat", "allow"),
+      capsFor: () => ["chat"],
     }));
     expect(result.outcome.kind).toBe("allow");
   });
 
   test("missing requiresCapability defaults to chat tier", async () => {
     const result = await applyCapabilityGate(7, "unknown_tool", {}, undefined, makeDeps({
-      evaluateCapability: (_agentId, _id, req) => {
-        expect(req).toBe("chat");
-        return decision(["chat"], "chat", "allow");
-      },
+      capsFor: () => ["chat"],
     }));
     expect(result.outcome.kind).toBe("allow");
     if (result.outcome.kind === "allow") expect(result.outcome.required).toBe("chat");
@@ -132,7 +115,7 @@ describe("applyCapabilityGate — capability_invalid_requestor", () => {
   test("null requestor_contact_id is treated as absent (default originator path)", async () => {
     const result = await applyCapabilityGate(7, "dc_send", { requestor_contact_id: null }, "chat", makeDeps({
       defaultOriginator: () => 50,
-      evaluateCapability: () => decision(["*"], "chat", "allow"),
+      capsFor: () => ["*"],
     }));
     // null acts as "not declared" — fall through to pairing contact.
     expect(result.outcome.kind).toBe("allow");
@@ -155,10 +138,10 @@ describe("applyCapabilityGate — capability_lookup_error", () => {
     }
   });
 
-  test("evaluateCapability throws (corrupt principal record)", async () => {
+  test("capsFor throws (corrupt Contact record)", async () => {
     const result = await applyCapabilityGate(7, "dc_send", {}, "chat", makeDeps({
       defaultOriginator: () => 50,
-      evaluateCapability: () => { throw new Error("schema mismatch in /path/principal/50.json") },
+      capsFor: () => { throw new Error("schema mismatch in /path/principal/50.json") },
     }));
     expect(result.outcome.kind).toBe("deny");
     if (result.outcome.kind === "deny") {
@@ -175,7 +158,7 @@ describe("applyCapabilityGate — capability_deny", () => {
   test("would_deny propagates as capability_deny with originator + caps", async () => {
     const result = await applyCapabilityGate(7, "dc_send_file", {}, "private_data_write", makeDeps({
       defaultOriginator: () => 200,
-      evaluateCapability: () => decision(["chat", "low_stakes_*"], "private_data_write", "would_deny"),
+      capsFor: () => ["chat", "low_stakes_*"], // does not cover private_data_write → would_deny
     }));
     expect(result.outcome.kind).toBe("deny");
     if (result.outcome.kind === "deny") {
@@ -194,9 +177,9 @@ describe("applyCapabilityGate — capability_deny", () => {
     const result = await applyCapabilityGate(7, "dc_send_file", { requestor_contact_id: 200 }, "private_data_write", makeDeps({
       defaultOriginator: () => 50, // subscriber, would have * caps
       getChatContacts: async () => [1, 50, 200],
-      evaluateCapability: (_agentId, id) => {
+      capsFor: (_chatId, id) => {
         expect(id).toBe(200); // gate must check requestor's caps, not subscriber's
-        return decision(["chat"], "private_data_write", "would_deny");
+        return ["chat"]; // does not cover private_data_write → would_deny
       },
     }));
     expect(result.outcome.kind).toBe("deny");
@@ -213,7 +196,7 @@ describe("applyCapabilityGate — scrubbedArgs", () => {
   test("requestor_contact_id is stripped from scrubbedArgs on allow", async () => {
     const result = await applyCapabilityGate(7, "dc_send", { chat_id: "7", text: "hi", requestor_contact_id: "200" }, "chat", makeDeps({
       getChatContacts: async () => [1, 50, 200],
-      evaluateCapability: () => decision(["chat"], "chat", "allow"),
+      capsFor: () => ["chat"],
     }));
     expect(result.scrubbedArgs).toEqual({ chat_id: "7", text: "hi" });
     expect("requestor_contact_id" in result.scrubbedArgs).toBe(false);
@@ -222,14 +205,14 @@ describe("applyCapabilityGate — scrubbedArgs", () => {
   test("requestor_contact_id is stripped from scrubbedArgs on deny", async () => {
     const result = await applyCapabilityGate(7, "dc_send", { chat_id: "7", requestor_contact_id: "200" }, "chat", makeDeps({
       getChatContacts: async () => [1, 50, 200],
-      evaluateCapability: () => decision(["chat"], "chat", "would_deny"),
+      capsFor: () => [], // empty caps → would_deny for "chat"
     }));
     expect("requestor_contact_id" in result.scrubbedArgs).toBe(false);
   });
 
   test("scrubbedArgs equals input when no requestor_contact_id was present", async () => {
     const result = await applyCapabilityGate(7, "dc_send", { chat_id: "7", text: "hi" }, "chat", makeDeps({
-      evaluateCapability: () => decision(["*"], "chat", "allow"),
+      capsFor: () => ["*"],
     }));
     expect(result.scrubbedArgs).toEqual({ chat_id: "7", text: "hi" });
   });

--- a/plugin/webxdc-app.ts
+++ b/plugin/webxdc-app.ts
@@ -19,8 +19,8 @@ export interface ToolDef {
   /**
    * Capability category required to invoke this tool (v1.3+).
    *
-   * Resolved against the originator's capability bundle by
-   * `plugin/access/capabilities.ts:evaluateCapability`. Tools without
+   * Resolved against the originator's capability bundle by the dispatcher's
+   * capability gate (`plugin/access/gate.ts`). Tools without
    * an annotation are treated as `chat`-tier (the safest default for
    * tools that read non-private data and post chat-shaped messages).
    *


### PR DESCRIPTION
## Summary

Collapses the per-tool-call capability double-load and the `evaluateCapability` pass-through. Pure refactor — identical authorization decisions, one Contact-record load per message instead of ~K+ (K = tool calls in a turn).

- **`decideCapability(caps, required)`** — new pure decision in `access/capabilities.ts` (terminal-`null` → allow; else `hasCapability`). No filesystem.
- **`_currentDriver`** now caches the sender's resolved caps `{ contactId, caps }`, computed once when the turn commits (caps optional + guarded — a corrupt sender record leaves it uncached so the gate still routes to `capability_lookup_error`).
- **`applyCapabilityGate`** swaps injected `evaluateCapability` for cache-aware `capsFor(chatId, originator)` + pure `decideCapability`. A declared `requestor_contact_id` re-resolves fresh (cache only serves the message sender).
- **`evaluateCapability` deleted** (its two callers — the gate and the terminal path — migrated; orphaned `getCapabilitiesFor` import removed; stale comments in gate.ts/index.ts/webxdc-app.ts fixed).
- Role changes now take effect on the sender's **next message** (not mid-turn); the `getCapabilitiesFor` "not memoized" comment + CONTEXT.md updated to match.

## Test plan

- [x] Access-layer suite green: `capabilities + gate + contacts + capability-bundles + access` → **134 pass / 0 fail**. `gate.test.ts` rewritten to inject `capsFor`; `capabilities.test.ts` rewritten so its role→decision integration runs through `decideCapability(getCapabilitiesFor(...))` (coverage preserved).
- [x] `tsc --noEmit` clean for `capabilities.ts` / `gate.ts` / `contact-policy.ts` / `server.ts` / `index.ts`.
- [x] `grep` confirms `evaluateCapability` is fully gone.
- [x] **Oliver review (review-oliver): REQUEST CHANGES → 1 P2, now fixed.** The P2 (message-start `getCapabilitiesFor` was outside the dispatch try, regressing the corrupt-record path from graceful per-tool denial to a whole-turn error) is resolved by guarding the resolution and leaving caps uncached on failure.
- [ ] Full `bun test` not run to completion here — it OOM/SIGKILLs in this multi-worktree environment (memory pressure), unrelated to the change; the access surface is the relevant gate and it's green.

## Landing notes

Dispatcher code — takes effect on a `bun server.ts` restart; intended for the pending **1.4.5** release. No user-visible behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)