### PR TITLE
refactor(dispatcher): own AgentDef→spawn-flags mapping in subagent-process

### DIFF
--- a/plugin/dispatcher/subagent-process.ts
+++ b/plugin/dispatcher/subagent-process.ts
@@ -14,7 +14,6 @@
  */
 
 import { spawn, execFileSync, type ChildProcessWithoutNullStreams } from 'node:child_process'
-import type { EffortLevel } from '../models.js'
 
 interface StreamFrame {
   type: string
@@ -25,14 +24,24 @@ interface StreamFrame {
   [k: string]: unknown
 }
 
+/** The slice of an agent definition the spawn needs. AgentDef satisfies it. */
+export interface SpawnAgent {
+  name: string
+  permissionMode?: string
+  tools?: string
+}
+
 export interface SubagentSpawnOptions {
   chatId: number
   subagentId: string
   /**
-   * Agent name — passed via `--agent` so CC reads the .md for
-   * model / prompt / tools / memory / permissionMode. Required.
+   * The agent to spawn. `name` → `--agent` (CC reads model / prompt / tools /
+   * memory from the .md). `permissionMode` / `tools` are forwarded as
+   * `--permission-mode` / `--allowed-tools` because CC's headless `-p` runtime
+   * does NOT apply the .md's permissionMode/tools to its grant decisions —
+   * without this, trusted agents deadlock on a UI-less permission prompt.
    */
-  agentName: string
+  agent: SpawnAgent
   /** Path to the generated per-subagent settings.json with the hook config. */
   settingsPath: string
   /** Path to the per-subagent mcp-config.json (loads dc tools-proxy). */
@@ -59,41 +68,7 @@ export interface SubagentSpawnOptions {
   claudeVersion?: string
   /** Session display name (synced with DC chat name). Passed as `--name`. */
   sessionName?: string
-  /**
-   * Permission mode forwarded to `--permission-mode`. CC reads the
-   * agent .md's `permissionMode` for some purposes, but does NOT use it
-   * to bypass tool-grant prompts in `-p` headless mode. The dispatcher
-   * reads the .md and forwards the value here so trusted agents (mode =
-   * `bypassPermissions`) can call MCP tools without deadlocking on a
-   * UI-less permission prompt.
-   */
-  permissionMode?: string
-  /**
-   * Pre-granted tool allowlist passed as `--allowed-tools`. The agent
-   * .md's `tools:` field declares the available surface but CC still
-   * prompts at use-time; pre-granting the same list here mirrors the
-   * v1.3 behavior. Pass the raw CSV from the .md.
-   */
-  allowedTools?: string
   logf?: (fmt: string, ...args: unknown[]) => void
-  /**
-   * @deprecated v1.4. CC reads model/effort/permissionMode/tools/system
-   * prompt from the agent .md. These options remain on the type for one
-   * release so callers compile while we migrate them, but they have no
-   * effect on the spawn argv. NL meta-commands mutate the .md directly
-   * via `agents.setAgentModel` / `setAgentEffort` / `setAgentTrust`.
-   */
-  model?: string
-  /** @deprecated v1.4. CC reads `effort` from the agent .md. */
-  effort?: EffortLevel
-  /** @deprecated v1.4. CC reads the system prompt (markdown body) from the .md. */
-  systemPrompt?: string
-  /** @deprecated v1.4. CC reads `tools` (CSV) from the agent .md. */
-  allowedBuiltinTools?: string[] | null
-  /** @deprecated v1.4. CC reads `tools` (CSV with `mcp__<server>` entries) from the agent .md. */
-  allowedMcpServers?: string[] | null
-  /** @deprecated v1.4 no-op (no verified CLI flag). Kept for caller compat. */
-  suppressUserClaudeMd?: boolean
 }
 
 /**
@@ -174,8 +149,8 @@ export const BUILTIN_TOOL_DESCRIPTIONS: Record<string, string> = {
 export function buildSubagentArgs(
   opts: SubagentSpawnOptions,
 ): { args: string[]; envBlock: string } {
-  if (!opts.agentName) {
-    throw new Error('buildSubagentArgs: agentName is required (v1.4 delegates to CC via --agent)')
+  if (!opts.agent || !opts.agent.name) {
+    throw new Error('buildSubagentArgs: agent.name is required (v1.4 delegates to CC via --agent)')
   }
   const tz = (() => { try { return Intl.DateTimeFormat().resolvedOptions().timeZone } catch { return 'unknown' } })()
   const lines = [
@@ -184,7 +159,7 @@ export function buildSubagentArgs(
     `- Timezone: ${tz}`,
     `- Working directory: ${opts.cwd ?? process.cwd()}`,
     `- Bound chat: ${opts.chatId}`,
-    `- Agent name: ${opts.agentName}`,
+    `- Agent name: ${opts.agent.name}`,
   ]
   if (opts.userName) lines.push(`- User: ${opts.userName}`)
   if (opts.claudeVersion) lines.push(`- Claude Code: ${opts.claudeVersion}`)
@@ -193,7 +168,7 @@ export function buildSubagentArgs(
 
   const args: string[] = [
     '-p',
-    '--agent', opts.agentName,
+    '--agent', opts.agent.name,
     ...(opts.resume ? ['--resume', opts.sessionId] : ['--session-id', opts.sessionId]),
     '--input-format', 'stream-json',
     '--output-format', 'stream-json',
@@ -207,14 +182,15 @@ export function buildSubagentArgs(
   // for every MCP tool the agent calls, with no UI to grant. The hook in
   // settings.json only matches built-ins (Bash/Edit/Write/…), not MCP
   // tools, so MCP grants would deadlock. Forward the mode explicitly.
-  if (opts.permissionMode) {
-    args.push('--permission-mode', opts.permissionMode)
+  if (opts.agent.permissionMode) {
+    args.push('--permission-mode', opts.agent.permissionMode)
   }
   // Same story for the allowlist: the .md's `tools:` field declares the
   // surface but CC still prompts at use-time for non-pre-granted tools.
   // Pass --allowed-tools so MCP calls (and any built-ins) are pre-granted.
-  if (opts.allowedTools && opts.allowedTools.length > 0) {
-    args.push('--allowed-tools', opts.allowedTools)
+  const allowedTools = opts.agent.tools ?? ''
+  if (allowedTools.length > 0) {
+    args.push('--allowed-tools', allowedTools)
   }
   if (opts.sessionName) {
     args.push('--name', opts.sessionName)
@@ -263,13 +239,6 @@ export class SubagentProcess {
     this.sessionId = opts.sessionId
     this.logf = opts.logf ?? (() => {})
 
-    if (opts.suppressUserClaudeMd) {
-      this.logf(
-        'subagent %s: suppressUserClaudeMd=true requested, but no verified ' +
-        'mechanism exists yet (Phase 1 deferred toggle). Ignoring.',
-        opts.subagentId,
-      )
-    }
     const { args } = buildSubagentArgs(opts)
     this.logf(
       'subagent %s: spawning chat=%d session=%s resume=%s',

--- a/plugin/server.ts
+++ b/plugin/server.ts
@@ -464,9 +464,11 @@ async function spawnSubagentForChat(chatId: number): Promise<SubagentProcess | n
 
   // resolved is non-null here — the early return at the top of this
   // function guarantees it once resolvedCheck succeeded. CC reads
-  // model/effort/permissionMode/tools/system prompt/memory from the
-  // agent .md via --agent <name>, so the dispatcher passes only DC
-  // runtime context.
+  // model/effort/system prompt/memory from the agent .md via --agent
+  // <name>, so the dispatcher passes only DC runtime context. The lone
+  // exception is permissionMode/tools, which `-p` mode does NOT apply to
+  // its grant decisions — SubagentProcess re-forwards those as explicit
+  // --permission-mode / --allowed-tools flags (see SpawnAgent).
   const agentDef = resolved!.agent
   try {
     assertCanSpawn(agentDef)

--- a/plugin/server.ts
+++ b/plugin/server.ts
@@ -479,17 +479,11 @@ async function spawnSubagentForChat(chatId: number): Promise<SubagentProcess | n
     }
     return null
   }
-  const agentName = agentDef.name
-  // CC's --agent flag doesn't propagate permissionMode / tools into the
-  // headless -p runtime's permission decisions; forward them explicitly
-  // so trusted agents skip prompts and MCP tools are pre-granted.
-  const permissionMode = agentDef.permissionMode
-  const allowedTools = agentDef.tools ?? ''
   let resumeFailed = false
   let sub = new SubagentProcess({
     chatId,
     subagentId,
-    agentName,
+    agent: agentDef,
     settingsPath,
     mcpConfigPath,
     dispatcherSocket: DISPATCHER_SOCKET,
@@ -501,8 +495,6 @@ async function spawnSubagentForChat(chatId: number): Promise<SubagentProcess | n
     sessionName,
     userName,
     claudeVersion: CLAUDE_VERSION,
-    permissionMode,
-    allowedTools,
     logf,
   })
   // Resume-fallback probe: if --resume was used and the child dies within
@@ -522,7 +514,7 @@ async function spawnSubagentForChat(chatId: number): Promise<SubagentProcess | n
       sub = new SubagentProcess({
         chatId,
         subagentId,
-        agentName,
+        agent: agentDef,
         settingsPath,
         mcpConfigPath,
         dispatcherSocket: DISPATCHER_SOCKET,
@@ -534,8 +526,6 @@ async function spawnSubagentForChat(chatId: number): Promise<SubagentProcess | n
         sessionName,
         userName,
         claudeVersion: CLAUDE_VERSION,
-        permissionMode,
-        allowedTools,
         logf,
       })
     }

--- a/plugin/test/subagent-process.test.ts
+++ b/plugin/test/subagent-process.test.ts
@@ -5,7 +5,7 @@ function baseOpts(extra: Partial<SubagentSpawnOptions> = {}): SubagentSpawnOptio
   return {
     chatId: 7,
     subagentId: 'sub-7-abcd',
-    agentName: 'test-agent',
+    agent: { name: 'test-agent' },
     settingsPath: '/tmp/settings.json',
     dispatcherSocket: '/tmp/sock',
     dispatcherSecret: 'secret',
@@ -17,7 +17,7 @@ function baseOpts(extra: Partial<SubagentSpawnOptions> = {}): SubagentSpawnOptio
 
 describe('buildSubagentArgs', () => {
   test('default args contain --agent <name> and core flags', () => {
-    const { args, envBlock } = buildSubagentArgs(baseOpts({ agentName: 'developer' }))
+    const { args, envBlock } = buildSubagentArgs(baseOpts({ agent: { name: 'developer' } }))
     expect(args).toContain('-p')
     expect(args).toContain('--agent')
     expect(args[args.indexOf('--agent') + 1]).toBe('developer')
@@ -31,33 +31,29 @@ describe('buildSubagentArgs', () => {
     expect(args).toContain('/tmp/settings.json')
     expect(args).toContain('--append-system-prompt')
     expect(envBlock).toContain('Bound chat: 7')
+    expect(envBlock).toContain('Agent name: developer')
   })
 
-  test('does NOT pass --model / --effort / --permission-mode / --allowedTools', () => {
-    const { args } = buildSubagentArgs(baseOpts({
-      agentName: 'developer',
-      model: 'claude-opus-4-7',  // ignored — set on the .md
-      effort: 'max',              // ignored — set on the .md
-    }))
+  test('a bare agent yields no --model / --effort / --permission-mode / --allowed-tools', () => {
+    // CC reads model/effort/permissionMode/tools/system prompt from the .md
+    // (via --agent); the dispatcher only forwards permissionMode/tools when
+    // the agent carries them. A bare agent forwards none of these flags.
+    const { args } = buildSubagentArgs(baseOpts({ agent: { name: 'developer' } }))
     expect(args).not.toContain('--model')
     expect(args).not.toContain('--effort')
     expect(args).not.toContain('--permission-mode')
-    expect(args).not.toContain('--allowedTools')
+    expect(args).not.toContain('--allowed-tools')
   })
 
-  test('--append-system-prompt contains env block only (no agent system prompt)', () => {
-    const { args, envBlock } = buildSubagentArgs(baseOpts({
-      agentName: 'developer',
-      systemPrompt: 'You are foo.',  // ignored; agent body lives in the .md
-    }))
+  test('--append-system-prompt contains the env block only (no agent system prompt)', () => {
+    const { args, envBlock } = buildSubagentArgs(baseOpts({ agent: { name: 'developer' } }))
     const idx = args.indexOf('--append-system-prompt')
     expect(args[idx + 1]).toBe(envBlock)
-    expect(envBlock).not.toContain('You are foo.')
   })
 
   test('resume=true uses --resume', () => {
     const { args } = buildSubagentArgs(baseOpts({
-      agentName: 'developer', sessionId: 'abc-123', resume: true,
+      agent: { name: 'developer' }, sessionId: 'abc-123', resume: true,
     }))
     expect(args).toContain('--resume')
     expect(args[args.indexOf('--resume') + 1]).toBe('abc-123')
@@ -66,7 +62,7 @@ describe('buildSubagentArgs', () => {
 
   test('--mcp-config is still passed (DC tools-proxy)', () => {
     const { args } = buildSubagentArgs(baseOpts({
-      agentName: 'developer', mcpConfigPath: '/tmp/mcp.json',
+      agent: { name: 'developer' }, mcpConfigPath: '/tmp/mcp.json',
     }))
     expect(args).toContain('--mcp-config')
     expect(args[args.indexOf('--mcp-config') + 1]).toBe('/tmp/mcp.json')
@@ -74,7 +70,7 @@ describe('buildSubagentArgs', () => {
 
   test('addDirs are passed as --add-dir', () => {
     const { args } = buildSubagentArgs(baseOpts({
-      agentName: 'developer', addDirs: ['/foo', '/bar'],
+      agent: { name: 'developer' }, addDirs: ['/foo', '/bar'],
     }))
     const dirs = args.reduce<string[]>((acc, v, i) => {
       if (args[i - 1] === '--add-dir') acc.push(v)
@@ -85,46 +81,47 @@ describe('buildSubagentArgs', () => {
 
   test('sessionName is passed as --name', () => {
     const { args } = buildSubagentArgs(baseOpts({
-      agentName: 'developer', sessionName: 'chat-foo',
+      agent: { name: 'developer' }, sessionName: 'chat-foo',
     }))
     expect(args).toContain('--name')
     expect(args[args.indexOf('--name') + 1]).toBe('chat-foo')
   })
 
-  test('forwards permissionMode via --permission-mode', () => {
+  test('forwards agent.permissionMode via --permission-mode', () => {
     const { args } = buildSubagentArgs(baseOpts({
-      agentName: 'trusted', permissionMode: 'bypassPermissions',
+      agent: { name: 'trusted', permissionMode: 'bypassPermissions' },
     }))
     expect(args).toContain('--permission-mode')
     expect(args[args.indexOf('--permission-mode') + 1]).toBe('bypassPermissions')
   })
 
-  test('omits --permission-mode when unset', () => {
-    const { args } = buildSubagentArgs(baseOpts({ agentName: 'untrusted' }))
+  test('omits --permission-mode when agent.permissionMode is unset', () => {
+    const { args } = buildSubagentArgs(baseOpts({ agent: { name: 'untrusted' } }))
     expect(args).not.toContain('--permission-mode')
   })
 
-  test('forwards allowedTools via --allowed-tools', () => {
+  test('forwards agent.tools via --allowed-tools', () => {
     // Use a real tool name (mcp__dc__reply — the cross-chat post tool;
     // registered as `reply` without a dc_ prefix) so this test doesn't
     // perpetuate the "dc_reply" naming confusion. The tool-name set is now
     // computed from the live registrations at boot, so there is no longer a
     // hand-maintained list to drift from.
     const { args } = buildSubagentArgs(baseOpts({
-      agentName: 'trusted',
-      allowedTools: 'Bash, Read, mcp__dc__reply',
+      agent: { name: 'trusted', tools: 'Bash, Read, mcp__dc__reply' },
     }))
     expect(args).toContain('--allowed-tools')
     expect(args[args.indexOf('--allowed-tools') + 1]).toBe('Bash, Read, mcp__dc__reply')
   })
 
-  test('omits --allowed-tools when allowedTools is empty', () => {
-    const { args } = buildSubagentArgs(baseOpts({ agentName: 'untrusted', allowedTools: '' }))
+  test('omits --allowed-tools when agent.tools is empty', () => {
+    const { args } = buildSubagentArgs(baseOpts({ agent: { name: 'untrusted', tools: '' } }))
     expect(args).not.toContain('--allowed-tools')
   })
 
-  test('throws if agentName is missing', () => {
-    expect(() => buildSubagentArgs(baseOpts({ agentName: undefined as unknown as string })))
-      .toThrow(/agentName is required/)
+  test('throws if agent.name is missing', () => {
+    expect(() => buildSubagentArgs(baseOpts({ agent: { name: undefined as unknown as string } })))
+      .toThrow(/agent\.name is required/)
+    expect(() => buildSubagentArgs(baseOpts({ agent: undefined as unknown as SubagentSpawnOptions['agent'] })))
+      .toThrow(/agent\.name is required/)
   })
 })


### PR DESCRIPTION
## What

Candidate 3 of the architecture-simplification pass. Moves the "which Agent-definition field becomes which `claude -p` CLI flag" mapping out of the dispatcher's spawn site and into `subagent-process.ts`, so the CC-compat translation lives in one place.

- `SubagentSpawnOptions` now takes a single **`agent: SpawnAgent`** (`{ name, permissionMode?, tools? }`) instead of the loose `agentName` / `permissionMode` / `allowedTools` trio. `buildSubagentArgs` derives `--agent` / `--permission-mode` / `--allowed-tools` from it; the dispatcher just passes `agent: agentDef` (`AgentDef` structurally satisfies `SpawnAgent`).
- Deletes the six dead **`@deprecated v1.4`** spawn options (`model`, `effort`, `systemPrompt`, `allowedBuiltinTools`, `allowedMcpServers`, `suppressUserClaudeMd`) — grep-confirmed set only by tests — plus the `suppressUserClaudeMd` no-op block in the constructor.

## Why

The `.md`→flag knowledge was split across two modules, and the spawn-site forwarding is exactly where the v1.4 "permissionMode not propagated → MCP-grant deadlock" regression lived. Consolidating it makes that mapping a single unit-tested function. Net −44 lines.

## Behavior

Pure refactor — **identical spawn argv** for every agent. Zero-value semantics preserved exactly (`tools ?? '' ` + `.length > 0`; truthy `permissionMode` guard). Dispatcher code → takes effect on a `bun server.ts` restart.

## Testing

- `test/subagent-process.test.ts` rewritten to the `agent` shape; 27/27 spawn tests pass, broader access/gate subset 66/66.
- `tsc --noEmit` clean project-wide (confirms no caller set the removed fields).
- Oliver review: APPROVE, 0 P1 / 0 P2 / 1 P3 (a stale adjacent comment) — P3 fixed in the second commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)